### PR TITLE
add Biarch to DESCRIPTION, fix #19

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,5 @@ SystemRequirements: OpenGL, GLU Library, XQuartz (on OSX),
     pandoc (>=1.14, needed for vignettes)
 BugReports: https://github.com/dmurdoch/rgl/issues
 VignetteBuilder: knitr
+Biarch: true
 Additional_repositories:  https://dmurdoch.github.io/drat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.105.14
+Version: 0.105.19
 Title: 3D Visualization Using OpenGL
 Author: Daniel Adler <dadler@uni-goettingen.de>, Duncan Murdoch <murdoch.duncan@gmail.com>, and others (see README)
 Maintainer: Duncan Murdoch <murdoch.duncan@gmail.com>

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1204,6 +1204,7 @@ base graphics.
   - Set up a drat repository to hold the unreleased webshot2
     package.
 
-0.105.14:
+0.105.19:
   - Fixed error in new args to snapshot3d (reported by Tony Hirst:
     https://github.com/dmurdoch/rgl/issues/21 .)
+  - Add Biarch to DESCRIPTION so both architectures are built on Windows


### PR DESCRIPTION
This PR is one solution to fix #19. It involves adding `Biarch: true` to the DESCRIPTION. I have tested that it successfully builds and passes CRAN checks on WinBuilder. Specifically, I used the R command `devtools::check_win_devel(vignettes = F)`. Please see attached files for WinBuilder results (note .Rout files have been renamed to .txt for GitHub compatibility):

[rgl-Ex_i386.txt](https://github.com/dmurdoch/rgl/files/5992165/rgl-Ex_i386.txt)
[rgl-Ex_x64.txt](https://github.com/dmurdoch/rgl/files/5992166/rgl-Ex_x64.txt)
[00install.txt](https://github.com/dmurdoch/rgl/files/5992160/00install.txt)
[rgl_0.105.14.zip](https://github.com/dmurdoch/rgl/files/5992161/rgl_0.105.14.zip)
[00check.txt](https://github.com/dmurdoch/rgl/files/5992159/00check.txt)
