### PR TITLE
delete configure.win, fix #19

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -1,1 +1,0 @@
-# No configuration needed on Windows


### PR DESCRIPTION
This PR is one solution to fix #19. It involves deleting the `configure.win` file. I have tested that it successfully builds and passes CRAN checks on WinBuilder. Specifically, I used the R command `devtools::check_win_devel(vignettes = F)`. Please see attached files for WinBuilder results (note .Rout files have been renamed to .txt for GitHub compatibility):

[00check.txt](https://github.com/dmurdoch/rgl/files/5992502/00check.txt)
[00install.txt](https://github.com/dmurdoch/rgl/files/5992503/00install.txt)
[rgl-Ex_i386.txt](https://github.com/dmurdoch/rgl/files/5992504/rgl-Ex_i386.txt)
[rgl-Ex_x64.txt](https://github.com/dmurdoch/rgl/files/5992505/rgl-Ex_x64.txt)
[rgl_0.105.14.zip](https://github.com/dmurdoch/rgl/files/5992506/rgl_0.105.14.zip)

**Please note that I am still drafting this PR. I wish to verify that this built version of rgl actually runs properly when installed on a Windows system before it is ready for review.**