### PR TITLE
Additional test for WebGL support, fixes issue #31.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.105.14
+Version: 0.105.15
 Title: 3D Visualization Using OpenGL
 Author: Daniel Adler <dadler@uni-goettingen.de>, Duncan Murdoch <murdoch.duncan@gmail.com>, and others (see README)
 Maintainer: Duncan Murdoch <murdoch.duncan@gmail.com>

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1204,6 +1204,7 @@ base graphics.
   - Set up a drat repository to hold the unreleased webshot2
     package.
 
-0.105.14:
+0.105.15:
   - Fixed error in new args to snapshot3d (reported by Tony Hirst:
     https://github.com/dmurdoch/rgl/issues/21 .)
+  - Improved test for presence of WebGL (suggested by Git Demont, https://github.com/dmurdoch/rgl/issues/31 ).

--- a/inst/htmlwidgets/lib/rglClass/init.src.js
+++ b/inst/htmlwidgets/lib/rglClass/init.src.js
@@ -4,7 +4,7 @@
      */
     rglwidgetClass.prototype.initGL0 = function() {
       if (!window.WebGLRenderingContext){
-        alert("Your browser does not support WebGL. See http://get.webgl.org");
+        this.alertOnce("Your browser does not support WebGL. See http://get.webgl.org");
         return;
       }
     };
@@ -14,7 +14,7 @@
      * @returns { Object } the WebGL context
      */
     rglwidgetClass.prototype.initGL = function() {
-      var self = this;
+      var self = this, success = false;
       if (this.gl) {
       	if (!this.drawing && this.gl.isContextLost())
           this.restartCanvas();
@@ -28,6 +28,9 @@
         this.onContextLost, false);
       this.gl = this.canvas.getContext("webgl", this.webGLoptions) ||
                this.canvas.getContext("experimental-webgl", this.webGLoptions);
+      success = !!(this.gl && this.gl instanceof WebGLRenderingContext);
+      if (!success)
+        this.alertOnce("Your browser does not support WebGL. See http://get.webgl.org"); 
       this.index_uint = this.gl.getExtension("OES_element_index_uint");
       var save = this.startDrawing();
       Object.keys(this.scene.objects).forEach(function(key){


### PR DESCRIPTION
Included test from issue #31 in the existing startup code.  I don't see the point of the expression `false | test`, and lint complained about it, so I omitted the `false |` part.

