### PR TITLE
Update README - install from .tgz

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -143,9 +143,9 @@ Binary builds of `rgl` are available for some platforms on CRAN.
 
 For source builds, install the prerequisites as described
 above, download
-the tarball and at the command line run
+the tarball from the [*Releases* page](https://github.com/dmurdoch/rgl/releases) and at the command line run
 
-    R CMD INSTALL rgl_`r packageVersion("rgl")`.tar.gz
+    R CMD INSTALL rgl-`r packageVersion("rgl")`.tar.gz
 
 (with the appropriate version of the tarball).  The build
 uses an `autoconf` configure script; to see the options, 
@@ -171,7 +171,7 @@ As of version 0.104.1, it is possible to build the package without
     --disable-opengl 
 For example,
   
-    R CMD INSTALL --configure-args="--disable-opengl" rgl_`r packageVersion("rgl")`.tar.gz 
+    R CMD INSTALL --configure-args="--disable-opengl" rgl-`r packageVersion("rgl")`.tar.gz 
   
   On Windows, OpenGL support cannot currently be disabled.
   


### PR DESCRIPTION
- give URL of page where releases / `.tgz` files can be found
- downloads (on Mac using Chrome, at least) are to `rgl-VERSION.tar.gz` *not* `rgl_VERSION.tar.gz`