### PR TITLE
drape3d()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,14 +20,15 @@ Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
               person("Jeroen", "Ooms", role = "ctb"),
               person("Yohann", "Demont", role = "ctb"),
               person("Joshua", "Ulrich", role = "ctb"),
-              person("Xavier", "Fernandez i Marin", role = "ctb"))
+              person("Xavier", "Fernandez i Marin", role = "ctb"),
+              person("George", "Helffrich", role = "ctb"))
 Depends: R (>= 3.3.0)
 Suggests: MASS, rmarkdown, deldir, orientlib, lattice, misc3d, rstudioapi,
           magick, plotrix (>= 3.7-3), tripack, interp, alphashape3d, tcltk,
           js (>= 1.2), akima, webshot2, downlit, pkgdown
 Imports: graphics, grDevices, stats, utils, 
          htmlwidgets, htmltools, knitr, jsonlite (>= 0.9.20), shiny,
-         magrittr, crosstalk, manipulateWidget (>= 0.9.0)
+         magrittr, crosstalk, manipulateWidget (>= 0.9.0), mgcv
 Description: Provides medium to high level functions for 3D interactive graphics, including
     functions modelled on base graphics (plot3d(), etc.) as well as functions for
     constructing representations of geometric objects (cube3d(), etc.).  Output

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,7 +7,7 @@ export(.check3d,
 	      clipMesh3d, clipObj3d, close3d, contourLines3d,
 	      cube3d, cuboctahedron3d, cur3d, 
         currentSubscene3d, cylinder3d,
-        decorate3d, deform.mesh3d, delFromSubscene3d, divide.mesh3d, dodecahedron3d, dot3d, ellipse3d, extrude3d,
+        decorate3d, deform.mesh3d, delFromSubscene3d, divide.mesh3d, dodecahedron3d, dot3d, drape3d, ellipse3d, extrude3d,
         figWidth, figHeight, filledContour3d,
 	gc3d, getr3dDefaults, getWidgetId, GramSchmidt, grid3d, 
 	highlevel, hook_rgl, hook_webgl,
@@ -130,6 +130,9 @@ export(.check3d,
  S3method(summary, rglscene)
  S3method(summary, rglsubscene)
  
+ S3method(drape3d, rglId)
+ S3method(drape3d, mesh3d)
+
  S3method(contourLines3d, rglId)
  S3method(contourLines3d, mesh3d)
  S3method(filledContour3d, rglId)

--- a/R/drape3d.R
+++ b/R/drape3d.R
@@ -1,0 +1,183 @@
+drape3d <- function(obj, ...) 
+  UseMethod("drape3d")
+
+drape3d.rglId <- function(obj, ...) 
+  drape3d(as.mesh3d(obj), ...)
+  
+drape3d.mesh3d <- function (obj, x, y = NULL, log = NULL, minVertices = 0,
+    plot = TRUE, z_offset = 0, TRI = NULL, ...) 
+{
+    ztri <- function(p){
+        ## Finds triangle with point p inside of it and returns z at that point
+        if(is.null(TRI)){
+            TRI <- array(NA,c(2,2,ncol(obj$it)))
+            for(j in 1:ncol(obj$it)){
+                v <- obj$it[,j]       ## vertices of triangle
+                TRI[,,j] <- matrix(c(range(verts[v,1]),range(verts[v,2])),2,2)
+            }
+        }
+        ## now TRI[,1,i] is x coord range for triangle i
+        ## now TRI[,2,i] is y coord range for triangle i
+        oo <- (p[1] < TRI[1,1,] | p[1] > TRI[2,1,]) &
+              (p[2] < TRI[1,2,] | p[2] > TRI[2,2,])
+        lam <- vector()
+        for(j in (1:ncol(obj$it))[!oo]){
+            ## get barycentric coords of p in triangle
+            v <- matrix(verts[obj$it[,j],],3,3)  ## v[i,] vertices of triangle i
+            D <- (v[2,2]-v[3,2]) * (v[1,1]-v[3,1]) +
+                 (v[3,1]-v[2,1]) * (v[1,2]-v[3,2])
+            l <- (v[2,2]-v[3,2]) * (p[1]  -v[3,1]) +
+                 (v[3,1]-v[2,1]) * (p[2]  -v[3,2])
+            lam[1] <- l/D
+            if (lam[1] < 0 || lam[1] > 1) next   ## not in this triangle
+            l <- (v[3,2]-v[1,2]) * (p[1]  -v[3,1]) +
+                 (v[1,1]-v[3,1]) * (p[2]  -v[3,2])
+            lam[2] <- l/D
+            if (lam[2] < 0 || lam[2] > 1) next   ## not in this triangle
+            lam[3] <- 1-sum(lam[1:2])
+            if (lam[3] < 0 || lam[3] > 1) next   ## not in this triangle
+            return(sum(lam*v[,3]))
+        }
+        NA
+    }
+
+    uniq <- function(...) mgcv::uniquecombs(...) ## current version
+
+    obj <- as.tmesh3d(obj)
+    nverts <- ncol(obj$vb)
+    oldnverts <- nverts - 1
+    while (nverts < minVertices && oldnverts < nverts) {
+        oldnverts <- nverts
+        obj <- subdivision3d(obj, deform = FALSE, normalize = TRUE)
+        nverts <- ncol(obj$vb)
+    }
+
+    verts <- asEuclidean(t(obj$vb))
+    result <- data.frame(x = numeric(), y = numeric(), z = numeric())
+
+    if (is.function(x)) {
+        fn <- x
+        verts <- t(verts)         ## verts is n x 3:  each row is a point
+        values <- (               ## values is 3 x t:  each col is a tri
+            fn(verts)
+        )[obj$it]
+        dim(values) <- dim(obj$it)
+        counts <-                 ## t vector: # pts cut by fn in each triangle
+            apply(values >= 0, 2, sum)
+        hits <-                   ## 3 x t matrix: each tri with two sides hit
+            obj$it[,counts == 2 | counts == 1]
+        if (ncol(hits)) {
+            hitValues <-          ## 3 x t matrix: values at vertex of each tri hit
+                values[,counts == 2 | counts == 1]
+            hitValues[hitValues == 0] <- .Machine$double.eps ## make 0 slightly +ve
+            pm <-                 ## +1,-1 depending on whether 2 pts>=0 or 1 pt>=0
+                apply(hitValues, 2, function(col) 2*sum(col >= 0)-3)
+            pm <-                 ## make 2 values positive in each triangle
+                matrix(rep(pm,each=3),3) * hitValues
+            vtx2 <- apply(pm, 2, function(col) which(col >= 0))
+            vtx1 <- apply(pm, 2, function(col) which(col < 0))
+            newvert <- matrix(NA, 2, 3)
+            for (j in 1:ncol(hitValues)) {
+                snglval <- hitValues[vtx1[j], j]
+                for (i in 1:2) {
+                    dublval <- hitValues[vtx2[i,j], j]
+                    alpha <- dublval/(dublval - snglval)
+                    newvert[i,] <-
+                      (1-alpha)*verts[,hits[vtx2[i,j], j]] +
+                         alpha *verts[,hits[vtx1[j], j]]
+                }
+                result <- rbind(result, data.frame(
+                    x=newvert[,1], y=newvert[,2], z=newvert[,3]
+                ))
+            }
+        }
+
+        if (plot) 
+            return(segments3d(result, ...))
+
+    } else {
+        segs <- xy.coords(x, y, log=log, recycle=FALSE, setLab=FALSE)
+
+        ## get unique point pairs making a triangle side in the grid
+        op <- function(v)v[if(v[1]>v[2])c(2,1) else c(1,2)] ## orders pair
+        tri <- matrix(NA,nrow=3*ncol(obj$it),ncol=2)
+        n <- 0
+        for (j in 1:ncol(obj$it)) {
+            v <- obj$it[,j]
+            tri[n<-n+1,] <- op(v[c(1,2)])
+            tri[n<-n+1,] <- op(v[c(2,3)])
+            tri[n<-n+1,] <- op(v[c(3,1)])
+        }
+        tri <- uniq(tri)
+
+        ## add first segment point assuming not on a triangle edge
+        z1 <- with(segs,ztri(c(x[1],y[1])))
+        if (!is.na(z1)) result <- with(segs,
+            rbind(result, data.frame( x=x[1], y=y[1], z=z1 + z_offset ))
+        )
+        for (i in 2:length(segs$x)){
+            p1 <- c(segs$x[i-1],segs$y[i-1])
+            p2 <- c(segs$x[i],segs$y[i])
+            p21 <- p2 - p1
+            if (any(is.na(p2))) {
+                ## add last segment point assuming not on triangle edge
+                zi <- ztri(p1)
+                if (!is.na(zi)) result <- rbind(result,
+                    data.frame( x=p1[1], y=p1[2], z=zi + z_offset )
+                )
+                next
+            }
+            if (any(is.na(p1))) {
+                ## NAs break line and move to next point
+                result <- rbind(result, data.frame( x=NA, y=NA, z=NA ))
+                zi <- ztri(p2)
+                if (!is.na(zi)) result <- rbind(result,
+                    data.frame( x=p2[1], y=p2[2], z=zi + z_offset )
+                )
+                next
+            }
+            zs <- matrix(NA,nrow=0,ncol=2)
+            s <- matrix(c(p1,p2),2,2)  ## speedup: winnow futile intersection calcs
+            s <- t(apply(s,1,op))
+            ## triangle seg x extent is all below or above line seg x extent
+            sx <- (verts[tri[,1],1] < s[1,1] & verts[tri[,2],1] < s[1,1]) |
+                  (verts[tri[,1],1] > s[1,2] & verts[tri[,2],1] > s[1,2])
+            ## triangle seg y extent is all below or above line seg y extent
+            sy <- (verts[tri[,1],2] < s[2,1] & verts[tri[,2],2] < s[2,1]) |
+                  (verts[tri[,1],2] > s[2,2] & verts[tri[,2],2] > s[2,2])
+            for(j in (1:nrow(tri))[!sx & !sy]){     ## possible intersections
+                p3 <- verts[tri[j,1],]
+                p4 <- verts[tri[j,2],]
+                p43 <- p4-p3
+                p31 <- p3[1:2]-p1
+                D <- -p21[1]*p43[2] + p21[2]*p43[1]
+                if (D == 0) next                    ## parallel line segs
+                T1<- -p31[1]*p43[2] + p31[2]*p43[1]
+                t1 <- T1/D
+                if (t1 < 0 || t1 > 1) next          ## not within p1 ... p2
+                T2<-  p21[1]*p31[2] - p21[2]*p31[1]
+                t2 <- T2/D
+                if (t2 < 0 || t2 > 1) next          ## not within p3 ... p4
+                zs <- rbind(zs,c(t1,(p3+t2*p43)[3]))## t1 along line seg & z value
+            }
+            if (nrow(zs)>0) {
+                ## add points in order of increasing t on segment
+                o <- order(zs[,1])
+                result <- rbind(result, data.frame(
+                    x=p1[1] + zs[o,1]*p21[1], y=p1[2] + zs[o,1]*p21[2],
+                    z=zs[o,2] + z_offset
+                ))
+            }
+        }
+
+        ## add last segment point assuming not on triangle edge
+        zn <- ztri(p2)
+        if (!is.na(zn)) result <- rbind(result,
+            data.frame( x=p2[1], y=p2[2], z=zn + z_offset )
+        )
+
+        if (plot) 
+            return(lines3d(result, ...))
+    }
+    result
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -240,4 +240,5 @@ Jeroen Ooms for Rtools40 and FreeType help.
 Yohann Demont for Shiny code, suggestions, and testing.  
 Joshua Ulrich for a lot of help with the Github migration.  
 Xavier Fernandez i Marin for help debugging the build.
+George Helffrich, draping code.
 

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -1,0 +1,119 @@
+\name{drape3d3d}
+\alias{drape3d}
+\title{
+Drape lines and intersections between surfaces over a scene.
+}
+\description{
+A line projected is projected onto the surface in a scene so that it appears
+to drape itself onto the surface.
+If the surface is a function where z = f(x,y) (like topography), then the line
+may be specified as a series of line segments.
+If the surface is a more general object, then the line is specified by the
+intersection of an arbitrary function (a plane, sphere, paraboloid) with the
+object.
+}
+\usage{
+drape3d(obj, x, y = NULL, log = NULL, minVertices = 0, plot = TRUE,
+    z_offset = 0, ...)
+}
+\arguments{
+  \item{obj}{
+The object(s) upon which to drape lines.
+}
+  \item{x}{
+\itemize{
+\item{ a function }
+\item{ any object that, along with \code{y}, is recognized by
+   \code{xy.coords} as yielding a set of (x,y) coordinate pairs }
+}
+One or more destination points.
+}
+  \item{log}{
+Logarithmic \code{x} or \code{y} data.
+See \code{xy.coords} for more information.
+}
+  \item{minVertices}{
+Improve the approximation to the surface when the function is non-linear.
+See Details below.
+}
+  \item{plot}{
+Should the lines be plotted, or returned as a data frame?
+}
+  \item{z_offset}{
+Amount to offset the lines painted on the surface from the surface itself.
+This can help improve the visibility of apparently intermittent lines on rough
+surfaces.
+}
+  \item{\dots}{
+For the \code{"mesh3d"} methods, additional parameters to pass to \code{\link{segments3d}} or \code{\link{lines3d}} 
+when drawing the draped lines.
+For the \code{"rglId"} methods, additional parameters to pass to the
+\code{"mesh3d"} methods.
+}
+}
+\details{
+If the resulting \code{x} and \code{y} values contain NA, the line segment
+ends and a new one starts with the next point.
+
+If \code{x} is a function, then it must accept a single matrix argument
+containing the \code{(x,y,z)} coordinates of each point \code{p[i]}, as shown
+in the following tableau:
+\preformatted{
+
+ / x[1]  x[2]  x[3] ... x[n] \
+ | y[1]  y[2]  y[3] ... y[n] |  .
+ \ z[1]  z[2]  z[3] ... z[n] /
+
+}
+It should return a vector \code{f(p[1]) ... f(p[n])}.  The intersection with
+the object is given by \code{f() = 0}.
+
+The \code{minVertices} argument is used to improve the
+approximation to the draping line when the function is non-linear.
+In that case, the interpolation between vertices
+can be inaccurate.  If \code{minVertices} is set to a positive
+number (e.g. \code{10000}), then the mesh is modified
+by subdivision to have at least that number of vertices,
+so that pieces are smaller and the linear interpolation
+is more accurate.
+}
+\value{
+If \code{plot = TRUE}, called mainly for the side effect of draping lines,
+it invisibly returns the object ID of the collection of lines. 
+
+If \code{plot = FALSE}, returns a data frame containing "x", "y" and "z"
+values for the line(s) (with NA separating each segment), or a data frame
+containing discontinuous segments
+}
+\author{
+George Helffrich
+}
+
+\examples{
+
+     # Drape a line over volcano topography, then intersect it with a
+     # ball of 150 m radius
+
+     z <- 2 * volcano        # Exaggerate the relief
+     x <- 10 * (1:nrow(z))   # 10 meter spacing (S to N)
+     y <- 10 * (1:ncol(z))   # 10 meter spacing (E to W)
+
+     open3d()
+     id <- persp3d(x, y, z, aspect = "iso",
+           axes = FALSE, box = FALSE, polygon_offset = 1)
+
+     segs <- list(x=range(x),y=range(y)+150)
+     drape3d(id, segs, col='yellow', lwd=3)
+     lines3d(list(x=segs$x,y=segs$y,z=rep(325,2)), col='red', lwd=3)
+
+     ball <- function(r,o){
+         function(x,R=r,O=o){
+             apply((x-matrix(O,3,ncol(x)))^2,2,sum)-R^2
+         }
+     }
+     drape3d(id, ball(125,c(350,200,320)), col='orange', lwd=3)
+
+     contourLines3d(id)     # "z" is the default function
+     filledContour3d(id, polygon_offset = 1, nlevels = 10, replace = TRUE)
+
+}

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -4,8 +4,8 @@
 Drape lines and intersections between surfaces over a scene.
 }
 \description{
-A line projected is projected onto the surface in a scene so that it appears
-to drape itself onto the surface.
+Project a line onto the surface in a scene so that it appears to drape itself
+onto the surface.
 If the surface is a function where z = f(x,y) (like topography), then the line
 may be specified as a series of line segments.
 If the surface is a more general object, then the line is specified by the
@@ -42,7 +42,7 @@ Should the lines be plotted, or returned as a data frame?
   \item{z_offset}{
 Amount to offset the lines painted on the surface from the surface itself.
 This can help improve the visibility of apparently intermittent lines on rough
-surfaces.
+surfaces.  For line draping only; use \code{polygon_offset} (see \code{\link{material3d}}) to offset intersections with general surfaces.
 }
   \item{\dots}{
 For the \code{"mesh3d"} methods, additional parameters to pass to \code{\link{segments3d}} or \code{\link{lines3d}} 
@@ -76,14 +76,19 @@ number (e.g. \code{10000}), then the mesh is modified
 by subdivision to have at least that number of vertices,
 so that pieces are smaller and the linear interpolation
 is more accurate.
+
+The result of line draping over surfaces where \code{z} is not \code{f(x,y)} is
+not uniquely defined and may change in future releases.
 }
 \value{
 If \code{plot = TRUE}, called mainly for the side effect of draping lines,
 it invisibly returns the object ID of the collection of lines. 
 
 If \code{plot = FALSE}, returns a data frame containing "x", "y" and "z"
-values for the line(s) (with NA separating each segment), or a data frame
-containing discontinuous segments
+values for the line(s) with NA separating each segment
+(for use with \code{\link{lines3d}}),
+or a data frame containing discontinuous segments
+(for use with \code{\link{segments3d}}). 
 }
 \author{
 George Helffrich
@@ -114,6 +119,52 @@ George Helffrich
      drape3d(id, ball(125,c(350,200,320)), col='orange', lwd=3)
 
      contourLines3d(id)     # "z" is the default function
+     filledContour3d(id, polygon_offset = 1, nlevels = 10, replace = TRUE)
+
+     # Outcrop pattern of planar rock layer on volcano topography
+
+     sd <- function(az,dip,p){
+        ## For plane described by (geologically defined) strike and dip given
+        ## by strike line azimuth az and plane dip dip (degrees) through point
+        ## p (x, y, z).  Returns a function that evaluates the equation for the
+        ## plane through that point given normal vector n[...] to plane.
+
+        cross <- function(a,b){
+           c(a[2]*b[3]-a[3]*b[2],a[3]*b[1]-a[1]*b[3],a[1]*b[2]-a[2]*b[1])
+        }
+        th <- pi/180*c(az,az+90,dip); sn <- sin(th[1:2]); co <- cos(th[1:2])
+        nrm <- cross(c(sn[1],co[1],0),c(sn[2],co[2],-tan(th[3])))
+        nrm <- nrm/sqrt(sum(nrm^2))
+        function(x,n=nrm,p0=p){
+           ## vectorized n[x]*(x-x0) + n[y]*(y-y0) + n[z]*(z-z0) = 0
+           n %*% ( x - matrix(p0,3,ncol(x)) )
+        }
+     }
+
+     # Add contourlines in "z" to a persp plot
+
+     z <- 2 * volcano        # Exaggerate the relief
+     x <- 10 * (1:nrow(z))   # 10 meter spacing (S to N)
+     y <- 10 * (1:ncol(z))   # 10 meter spacing (E to W)
+
+     open3d()
+     id <- persp3d(x, y, z, aspect = "iso",
+           axes = FALSE, box = FALSE, polygon_offset = 1)
+
+     p <- c(350,205)         # (x,y) of strike & dip reading
+     off <- 10*c(-1,+1)      # X-marks-the-spot offset
+     segs <- list(
+          x=c(p[1]+off,NA,p[1]+off),
+          y=c(p[2]+off,NA,p[2]-off),
+          z=rep(350,5)
+     )
+     pts <- drape3d(id, segs, plot=FALSE)
+     lines3d(pts, col='magenta', lwd=2) # draw X on topography at point
+
+     pz <- mean(pts$z[!is.na(pts$z)])
+     drape3d(id, sd(45, 10, c(p,pz)), col='yellow', lwd=2)
+
+     contourLines3d(id)      # "z" is the default function
      filledContour3d(id, polygon_offset = 1, nlevels = 10, replace = TRUE)
 
 }

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -28,6 +28,9 @@ The object(s) upon which to drape lines.
 }
 which describes the lines to be draped.
 }
+  \item{y}{
+  See \code{y}.
+}
   \item{log}{
 Logarithmic \code{x} or \code{y} data.
 See \code{xy.coords} for more information.

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -26,7 +26,7 @@ The object(s) upon which to drape lines.
 \item{ any object that, along with \code{y}, is recognized by
    \code{xy.coords} as yielding a set of (x,y) coordinate pairs }
 }
-One or more destination points.
+which describes the lines to be draped.
 }
   \item{log}{
 Logarithmic \code{x} or \code{y} data.
@@ -52,9 +52,6 @@ For the \code{"rglId"} methods, additional parameters to pass to the
 }
 }
 \details{
-If the resulting \code{x} and \code{y} values contain NA, the line segment
-ends and a new one starts with the next point.
-
 If \code{x} is a function, then it must accept a single matrix argument
 containing the \code{(x,y,z)} coordinates of each point \code{p[i]}, as shown
 in the following tableau:
@@ -66,7 +63,7 @@ in the following tableau:
 
 }
 It should return a vector \code{f(p[1]) ... f(p[n])}.  The intersection with
-the object is given by \code{f() = 0}.
+the object is defined by \code{f() = 0}.
 
 The \code{minVertices} argument is used to improve the
 approximation to the draping line when the function is non-linear.
@@ -89,6 +86,9 @@ values for the line(s) with NA separating each segment
 (for use with \code{\link{lines3d}}),
 or a data frame containing discontinuous segments
 (for use with \code{\link{segments3d}}). 
+For lines, if the resulting "x" and "y" values contain NA, the line segment
+ends and a new one starts with the next point.  Segments are defined by
+successive pairs of points and are unordered.
 }
 \author{
 George Helffrich
@@ -112,6 +112,7 @@ George Helffrich
      lines3d(list(x=segs$x,y=segs$y,z=rep(325,2)), col='red', lwd=3)
 
      ball <- function(r,o){
+         ## vectorized (x-x0)^2 + (y-y0)^2 + (z-z0)^2 - R^2 = 0
          function(x,R=r,O=o){
              apply((x-matrix(O,3,ncol(x)))^2,2,sum)-R^2
          }
@@ -124,20 +125,22 @@ George Helffrich
      # Outcrop pattern of planar rock layer on volcano topography
 
      sd <- function(az,dip,p){
-        ## For plane described by (geologically defined) strike and dip given
-        ## by strike line azimuth az and plane dip dip (degrees) through point
-        ## p (x, y, z).  Returns a function that evaluates the equation for the
+        ## For plane described by (geologically defined)
+        ## strike and dip given by strike line azimuth az
+        ## and plane dip dip (degrees) through point p (x, y, z).
+        ## Returns a function that evaluates the equation for the
         ## plane through that point given normal vector n[...] to plane.
 
         cross <- function(a,b){
            c(a[2]*b[3]-a[3]*b[2],a[3]*b[1]-a[1]*b[3],a[1]*b[2]-a[2]*b[1])
         }
-        th <- pi/180*c(az,az+90,dip); sn <- sin(th[1:2]); co <- cos(th[1:2])
+        th <- pi/180*c(az,az+90,dip)
+        sn <- sin(th[1:2]); co <- cos(th[1:2])
         nrm <- cross(c(sn[1],co[1],0),c(sn[2],co[2],-tan(th[3])))
         nrm <- nrm/sqrt(sum(nrm^2))
         function(x,n=nrm,p0=p){
            ## vectorized n[x]*(x-x0) + n[y]*(y-y0) + n[z]*(z-z0) = 0
-           n %*% ( x - matrix(p0,3,ncol(x)) )
+           n \%*\% ( x - matrix(p0,3,ncol(x)) )
         }
      }
 
@@ -159,7 +162,7 @@ George Helffrich
           z=rep(350,5)
      )
      pts <- drape3d(id, segs, plot=FALSE)
-     lines3d(pts, col='magenta', lwd=2) # draw X on topography at point
+     lines3d(pts, col='magenta', lwd=2) # X on topography at point
 
      pz <- mean(pts$z[!is.na(pts$z)])
      drape3d(id, sd(45, 10, c(p,pz)), col='yellow', lwd=2)

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -92,7 +92,7 @@ George Helffrich
 \examples{
 
      # Drape a line over volcano topography, then intersect it with a
-     # ball of 150 m radius
+     # ball of 125 m radius
 
      z <- 2 * volcano        # Exaggerate the relief
      x <- 10 * (1:nrow(z))   # 10 meter spacing (S to N)

--- a/man/drape3d.Rd
+++ b/man/drape3d.Rd
@@ -1,4 +1,4 @@
-\name{drape3d3d}
+\name{drape3d}
 \alias{drape3d}
 \title{
 Drape lines and intersections between surfaces over a scene.

--- a/vignettes/rgl.Rmd
+++ b/vignettes/rgl.Rmd
@@ -183,6 +183,7 @@ Function                      | Description
 `r indexfns(c("sprites3d", "particles3d"))`: | add sprites (fixed shapes or images) to plot
 `r indexfns("spheres3d")`:    | adds spheres
 `r indexfns(c("surface3d", "terrain3d"))`:    | a surface (as used in `r linkfn("persp3d")`)
+`r indexfns("drape3d")`:      | drapes lines on a surface or object(s)
 `r indexfns("arrow3d")`:      | add an arrow to a scene
 `r indexfns("pch3d")`:	      | draw base-style plotting symbols
 `r indexfns("plotmath3d")`:   | used by `r linkfn("text3d")` for math text


### PR DESCRIPTION
Adds new function drape3d() to drape a line over z=f(x,y) surface or an intersection of a function with an object collection.

Generalized to handle draping on arbitrary objects from originally proposed design, based on discussions with dmurdoch.