### PR TITLE
Fix Freetype issues on Windows; update font code and docs.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.106.0
+Version: 0.106.2
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.106.0 
+# rgl  0.106.2
 
 ## Major changes
 
@@ -32,7 +32,11 @@
 *  Set "window_group" in X11 so `rgl` windows are grouped,
    based on code by Ivan Krylov. 
 *  `filledContour3d()` now accepts levels in decreasing order. 
-*  `mergeVertices()` and `as.mesh3d.rglId()` have been improved. 
+*  `mergeVertices()` and `as.mesh3d.rglId()` have been improved.
+*  `r3dDefaults$useFreeType` is now set to `FALSE` on 
+Windows, so that system fonts will be used by default.
+*  Text `family = "symbol"` has never really worked,
+   and is no longer recommended.
 
 ## Bug fixes 
 

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -1,5 +1,6 @@
-# The rgl font database is only used when rgl is configured for freetype.  
-# Usually this is not true in Windows, and the windowsFonts are used instead.
+# The rgl font database is only used when rgl is configured for FreeType.  
+# Since 0.105.13 this is always true on Windows, but since 0.106.2
+# r3dDefaults sets useFreeType to FALSE, so the windowsFonts() are used instead.
 
 # This code is closely modelled on the Quartz font database.
 

--- a/R/r3d.rgl.R
+++ b/R/r3d.rgl.R
@@ -301,6 +301,9 @@ r3dDefaults <- list(userMatrix = rotationMatrix(290*pi/180, 1, 0, 0),
 		  family = "sans",
 		  material = list(color="black", fog = TRUE))
 
+if (.Platform$OS.type == "windows")
+	r3dDefaults$useFreeType <- FALSE
+
 open3d <- function(..., params = getr3dDefaults(), 
                    useNULL = rgl.useNULL(), silent = FALSE	) {
 	

--- a/man/open3d.Rd
+++ b/man/open3d.Rd
@@ -45,7 +45,9 @@ r3dDefaults
   values for parameters.  As installed this sets the point of view to
   'world coordinates' (i.e. x running from left to right, y from front
   to back, z from bottom to top), the \code{mouseMode} to
-  \code{(zAxis, zoom, fov)}, and the field of view to 30 degrees.
+  \code{(zAxis, zoom, fov)}, and the field of view to 30 degrees.  \code{useFreeType} defaults to \code{FALSE} on 
+  Windows; on other systems it indicates the availability
+  of FreeType.
   Users may create their own variable named \code{r3dDefaults} in the global
   environment and it will override the installed one.  If there
   is a \code{bg} element in the list or the arguments, it should be

--- a/man/par3d.Rd
+++ b/man/par3d.Rd
@@ -91,9 +91,9 @@ par3d(\dots, no.readonly = FALSE, dev = cur3d(),
     OpenGL driver may not support the requested number, in which case
     \code{par3d("antialias")} will report what was actually set. Applies to the whole device.}    
     \item{\code{cex}}{real.  The default size for text.}
-    \item{\code{family}}{character.  The default device independent family name; see \code{\link{text3d}}.
+    \item{\code{family}}{character.  The default device independent family name; see \code{\link{rgl.texts}}.
     Applies to the whole device.}
-    \item{\code{font}}{integer.  The default font number (from 1 to 5; see \code{\link{text3d}}).
+    \item{\code{font}}{integer.  The default font number (from 1 to 4; see \code{\link{rgl.texts}}).
     Applies to the whole device.}
     \item{\code{useFreeType}}{logical.  Should FreeType fonts be used?
     Applies to the whole device.}
@@ -190,6 +190,10 @@ As of version 0.100.32, when changing the \code{"windowRect"} parameter, the
 \code{"viewport"} for the root (or specified) subscene
 is changed immediately.  This fixes a bug where in earlier
 versions it would only be changed when the window was redrawn, potentially after another command making use of the value.
+
+Default values are not described here, as several of them
+are changed by the \code{\link{r3dDefaults}} variable when
+the window is opened by \code{\link{open3d}}.
 }
 
 \section{Rendering}{

--- a/man/rgl.texts.Rd
+++ b/man/rgl.texts.Rd
@@ -26,7 +26,7 @@ rglFonts(...)
   overrides any \code{adj} value given. Values of 1, 2, 3 and 4, respectively indicate positions below, to the left of, above and to the right of the specified coordinates.}
   \item{offset}{ when \code{pos} is specified, this value gives the offset of the label from the specified coordinate in fractions of a character width.}
   \item{ family }{A device-independent font family name, or "" }
-  \item{ font }{A numeric font number from 1 to 5 }
+  \item{ font }{A numeric font number from 1 to 4 }
   \item{ cex }{A numeric character expansion value }
   \item{ useFreeType }{logical.  Should FreeType be used to draw text? (See details below.)}
   \item{ ... }{In \code{rgl.texts}, material properties; see \code{\link{rgl.material}} for details.  In \code{rglFonts}, device dependent font definitions for use with FreeType.}  
@@ -52,7 +52,9 @@ families \cr
 are normally
 available, but users may add additional families.  \code{font} numbers
 are restricted to the range 1 to 4 for standard, bold, italic and bold italic
-respectively; with font 5 recoded as family \code{"symbol"} font 1.  
+respectively.  Font 5 is recoded as family \code{"symbol"}
+font 1, but that is not supported unless specifically
+installed, so should be avoided.
 
 Using an unrecognized value for \code{"family"} will result in
 the system standard font as used in RGL up to version 0.76.  That font
@@ -60,7 +62,7 @@ is not resizable and \code{font} values are ignored.
 
 If \code{useFreeType} is \code{TRUE}, then RGL will use the FreeType
 anti-aliased fonts for drawing.  This is generally desirable, and it is the
-default if RGL was built to support FreeType.  
+default on non-Windows systems if RGL was built to support FreeType.
 
 FreeType fonts are specified using the \code{rglFonts} function.  This function
 takes a vector of four filenames of TrueType font files which
@@ -72,6 +74,12 @@ regular versions of the \code{serif}, \code{sans} and \code{mono} families.
 Additional free font files are available from the Amaya project at
 \url{https://dev.w3.org/cvsweb/Amaya/fonts/}.  See the example below for
 how to specify a full set of fonts.
+
+On Windows the system fonts are acceptable and are used
+when \code{useFreeType = FALSE} (the current default in
+\code{\link{r3dDefaults}}).  Mappings to \code{family} names
+are controlled by the \code{grDevices::windowsFonts()}
+function.
 
 Full pathnames should normally be used to specify font files.  If relative
 paths are used, they are interpreted differently by platform.  Currently

--- a/man/texts.Rd
+++ b/man/texts.Rd
@@ -53,10 +53,10 @@ invisibly.
 }
 \examples{
 open3d()
-famnum <- rep(1:4, 8)
-family <- c("serif", "sans", "mono", "symbol")[famnum]
-font <- rep(rep(1:4, each = 4), 2)
-cex <- rep(1:2, each = 16)
+famnum <- rep(1:3, 8)
+family <- c("serif", "sans", "mono")[famnum]
+font <- rep(rep(1:4, each = 3), 2)
+cex <- rep(1:2, each = 12)
 text3d(font, cex, famnum, text = paste(family, font), adj = 0.5, 
        color = "blue", family = family, font = font, cex = cex)
 }


### PR DESCRIPTION
Addition of FreeType libs to Windows build made font handling worse there; this defaults to system fonts instead.  There are also updates to the docs and examples to avoid the `"symbol"` family and `font = 5`; these have never really worked in `rgl`.