### PR TITLE
Restore compatibility with knitr PR#1892

### DIFF
--- a/R/knitr.R
+++ b/R/knitr.R
@@ -17,8 +17,8 @@ in_knitr <- function()
 oldKnitrVersion <- function() 
   !all(c("wrap", "is_low_change") %in% getNamespaceExports("knitr"))
 
-# This is only needed for old knitr:
-globalVariables("wrap")
+if (!oldKnitrVersion())
+  wrap <- getExportedValue("knitr", "wrap")
 
 fns <- local({
   newwindowdone <- FALSE
@@ -477,7 +477,7 @@ fns <- local({
       if (!latex)
         class(result) <- c(class(result), "knit_asis_htmlwidget")
       
-      knitr::wrap(result, options)
+      wrap(result, options)
     }
     
     list(

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -228,6 +228,12 @@ fns <- local({
         return()
       }
       counter <<- 0L
+      registerS3method("wrap", "rglRecordedplot", 
+                       wrap.rglRecordedplot, 
+                       envir = asNamespace("knitr"))
+      registerS3method("is_low_change", "rglRecordedplot",
+                       is_low_change.rglRecordedplot,
+                       envir = asNamespace("knitr"))
     }
     setupDone <<- list(autoprint = autoprint,
                        rgl.newwindow = rgl.newwindow,
@@ -275,7 +281,7 @@ fns <- local({
                      width = figWidth(),
                      height = figHeight(),
                      options = options, args = args),
-                class = "rglRecordedplot")
+                class = c("rglRecordedplot", "knit_other_plot"))
     } else
       invisible(x)
   }
@@ -443,8 +449,7 @@ fns <- local({
       content <- rglwidget(scene,
                            width = x$width,
                            height = x$height,
-                           webgl = !doSnapshot,
-                           latex = latex)
+                           webgl = !doSnapshot)
       if (inherits(content, "knit_image_paths")) {
         # # We've done a snapshot, put it in the right place.
         name <- file.path(options$fig.path,
@@ -472,7 +477,7 @@ fns <- local({
       if (!latex)
         class(result) <- c(class(result), "knit_asis_htmlwidget")
       
-      wrap(result, options)
+      knitr::wrap(result, options)
     }
     
     list(


### PR DESCRIPTION
Sometime in the last 7 months, `rgl` lost compatibility with https://github.com/yihui/knitr/pull/1892.  This restores it.