### PR TITLE
Fix bbox miscalculation in NULL device

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.14
+Version: 0.108.15
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl  0.108.14
+# rgl  0.108.15
 
 ## Major changes
 
@@ -45,6 +45,8 @@ boxes were not computed consistently (issue #169).
 so they failed after a redraw (issue #173).
 * Buffers are now optional, as they don't work with 
 Shiny scene changes (also issue #173).
+* The NULL device would sometimes miscalculate the
+bounding box.
     
 # rgl 0.108.5
 

--- a/src/NULLgui.cpp
+++ b/src/NULLgui.cpp
@@ -29,7 +29,7 @@ public:
   void show() {};
   void hide() {};
   void bringToTop(int stay) {};
-  void update() { if (window) window->paint(); };
+  void update() { if (window && !window->skipRedraw) window->paint(); };
   void destroy() { if (window) window->notifyDestroy(); };
   void captureMouse(View* pView) {};
   void releaseMouse() {};


### PR DESCRIPTION
The NULL device called paint() even when skipRedraw was set.