### PR TITLE
Fix selection when closest=TRUE and there are multiple objects.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.15
+Version: 0.108.16
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl  0.108.15
+# rgl  0.108.16
 
 ## Major changes
 
@@ -47,6 +47,8 @@ so they failed after a redraw (issue #173).
 Shiny scene changes (also issue #173).
 * The NULL device would sometimes miscalculate the
 bounding box.
+* `selectpoints3d(closest = TRUE)` selected too many points
+when multiple objects were in the scene.
     
 # rgl 0.108.5
 

--- a/R/selectpoints3d.R
+++ b/R/selectpoints3d.R
@@ -3,17 +3,17 @@ selectpoints3d <- function(objects = ids3d()$id, value = TRUE, closest = TRUE,
 
   if (value) result <- cbind(x = numeric(0), y = numeric(0), z = numeric(0))
   else result <- cbind(id = integer(0), index = integer(0))
-  rdist <- I
 
   first <- TRUE
+  prevdist <- dist <- Inf
+  
   while (first || is.function(multiple) || multiple) {
     f <- select3d(...)
     if (is.null(f)) break
     
     e <- environment(f)
     
-    dist <- Inf
-    prev <- nrow(result)
+    prev <- nrow(result) # Number to keep from previous selection
     
     for (id in objects) {
       verts <- rgl.attrib(id, "vertices")
@@ -41,8 +41,10 @@ selectpoints3d <- function(objects = ids3d()$id, value = TRUE, closest = TRUE,
       
       if (!any(hits)) next
       
-      if (prev && nrow(result) > prev  && rdist > dist)
-        result <- result[seq_len(prev),,drop=FALSE]
+      if (prev && prevdist > dist) {
+        result <- result[FALSE, , drop = FALSE]
+        prev <- 0
+      }
         
       if (value)
         result <- rbind(result, verts[hits,])
@@ -53,8 +55,8 @@ selectpoints3d <- function(objects = ids3d()$id, value = TRUE, closest = TRUE,
           && !multiple(result[(prev+1):nrow(result),,drop=FALSE]))
         break  
         
-      rdist <- dist
-      
+      prevdist <- dist
+      prev <- nrow(result)
       first <- FALSE
     }
     

--- a/man/selectpoints3d.Rd
+++ b/man/selectpoints3d.Rd
@@ -60,6 +60,9 @@ If \code{value} is \code{FALSE}, a 2-column matrix containing columns:
 If multiple points have the same coordinates, all indices will be returned.}
 
 }
+\note{This function selects points, not areas.  For example,
+if the selection region is in the interior of the triangle, that
+will count as a miss for all of the triangle's vertices.}
 \author{
 Duncan Murdoch
 }


### PR DESCRIPTION
The example here:  https://stackoverflow.com/q/71209023/2554330 found too many points when `closest = TRUE` was used.