### PR TITLE
When skipRedraw is set, graphs shouldn't print in knitr and relatives.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.23
+Version: 0.108.24
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.108.23
+# rgl  0.108.24
 
 ## Major changes
 
@@ -63,6 +63,8 @@ bounding box.
 * `selectpoints3d(closest = TRUE)` selected too many points
 when multiple objects were in the scene.
 * Clearing nested subscenes could cause a segfault and crash.
+* In `knitr` and `rmarkdown`, blank plots could be shown
+when `par3d(skipRedraw=TRUE)` was set (issue #188).
     
 # rgl 0.108.5
 

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -27,10 +27,12 @@ rglId <- function(ids = integer()) {
 
 print.rglId <- function(x, rglwidget = getOption("rgl.printRglwidget", FALSE),
 			...) {
-  if (rglwidget)
-    # FIXME:  For lowlevel, this should replace the scene, not update the history
-    print(rglwidget(...))
-  else if (in_pkgdown_example())
-    pkgdown::pkgdown_print(x)
+  if (!par3d("skipRedraw")) {
+    if (rglwidget)
+      # FIXME:  For lowlevel, this should replace the scene, not update the history
+      print(rglwidget(...))
+    else if (in_pkgdown_example())
+      pkgdown::pkgdown_print(x)
+  }
   invisible(x)
 }

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -222,7 +222,7 @@ fns <- local({
   }
   
   knit_print.rglId <- function(x, options, ...) {
-    if (getOption("rgl.printRglwidget", FALSE))	{
+    if (getOption("rgl.printRglwidget", FALSE) && !par3d("skipRedraw"))	{
       scene <- scene3d()
       args <- list(...)
       if (inherits(x, "rglHighlevel"))


### PR DESCRIPTION
This fixes issue #188 .