### PR TITLE
Only draw textured objects once.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.26
+Version: 0.108.27
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.108.26
+# rgl  0.108.27
 
 ## Major changes
 
@@ -67,6 +67,9 @@ when multiple objects were in the scene.
 when `par3d(skipRedraw=TRUE)` was set (issue #188).
 * Objects drawn with `sprites3d()` weren't lit correctly
 in WebGL (issue #189).
+* Objects with textures were sometimes drawn more than once, both
+before the texture loaded and after.  This was most noticeable for
+objects with user textures.
     
 # rgl 0.108.5
 

--- a/inst/htmlwidgets/lib/rglClass/draw.src.js
+++ b/inst/htmlwidgets/lib/rglClass/draw.src.js
@@ -521,6 +521,9 @@
         
       if (!obj.initialized)
         this.initObj(obj);
+        
+      if (this.texturesLoading)
+        return[];
 
       count = obj.vertexCount;
       if (!count)

--- a/inst/htmlwidgets/lib/rglClass/textures.src.js
+++ b/inst/htmlwidgets/lib/rglClass/textures.src.js
@@ -73,8 +73,13 @@
          ctx.imageSmoothingEnabled = true;
          ctx.drawImage(image, 0, 0, canvasX, canvasY);
          self.handleLoadedTexture(texture, canvas);
-         self.drawScene();
+         self.texturesLoading -= 1;
+         if (!self.texturesLoading)
+           self.drawScene();
        };
+       if (!self.texturesLoading)
+         self.texturesLoading = 0; // may have been undefined
+       self.texturesLoading += 1;
        image.src = uri;
      };
 


### PR DESCRIPTION
Objects were sometimes drawn both before and after texture loading.  This fixes https://github.com/dmurdoch/rgl2gltf/issues/28