### PR TITLE
Fix missing tick labels in `snapshot3d`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.27
+Version: 0.108.28
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.108.27
+# rgl  0.108.28
 
 ## Major changes
 
@@ -70,6 +70,8 @@ in WebGL (issue #189).
 * Objects with textures were sometimes drawn more than once, both
 before the texture loaded and after.  This was most noticeable for
 objects with user textures.
+* Tick labels were sometimes lost in WebGL displays and
+`snapshot3d()` results (issue #197).
     
 # rgl 0.108.5
 

--- a/inst/htmlwidgets/lib/rglClass/axes.src.js
+++ b/inst/htmlwidgets/lib/rglClass/axes.src.js
@@ -76,7 +76,8 @@
         case "custom":
           for (i=0; i < obj.vertices.length; i++) {
             value = (obj.vertices[i][dim] - limits[0])/range;
-            if (typeof value !== "undefined")
+            if (typeof value !== "undefined" &&
+                !isNaN(value))
               result[dim].push(value);
           }
           break;
@@ -158,6 +159,8 @@
         locations = ticks.locations[dim];
         if (locations.length)
           for (i = 0; i < locations.length; i++) {
+            if (isNaN(locations[i]))
+              continue;
             while (j < tickvertices.length && 
                    tickvertices[j][dim] !== locations[i]) j++;
             if (j >= tickvertices.length)


### PR DESCRIPTION
This fixes issue #197 .