### PR TITLE
Fix warnings from new material properties.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.29
+Version: 0.108.30
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.108.29
+# rgl  0.108.30
 
 ## Major changes
 
@@ -73,6 +73,8 @@ objects with user textures.
 * Axis mode `"pretty"` got lost when scenes were redrawn.
 * Tick labels were sometimes lost in WebGL displays and
 `snapshot3d()` results (issue #197).
+* The new material properties from 0.107.10 and 0.108.3
+were not handled properly by `plotmath3d()`.
     
 # rgl 0.108.5
 

--- a/R/plotmath3d.R
+++ b/R/plotmath3d.R
@@ -4,6 +4,7 @@ plotmath3d <- function(x, y = NULL, z = NULL,
 		       pos = NULL, offset = 0.5,
 		       fixedSize = TRUE,
 		       startsize = 480, initCex = 5, 
+		       margin = "", floating = FALSE, tag = "",
 		       ...) {
   xyz <- xyz.coords(x, y, z)
   n <- length(xyz$x)
@@ -50,7 +51,8 @@ plotmath3d <- function(x, y = NULL, z = NULL,
     result[i] <- with(xyz, sprites3d(x[i], y[i], z[i], texture = f, textype = "rgba", 
             col = "white", lit = FALSE, radius = cex[i]*size/initCex/20,
             adj = adj, pos = posi, offset = offseti,
-            fixedSize = fixedSize))
+            fixedSize = fixedSize,
+            margin = margin, floating = floating, tag = tag))
   }
   lowlevel(result)
 }

--- a/man/plotmath3d.Rd
+++ b/man/plotmath3d.Rd
@@ -11,7 +11,8 @@ file as a texture in a sprite.
 \usage{
 plotmath3d(x, y = NULL, z = NULL, text, cex = par("cex"),
            adj = 0.5, pos = NULL, offset = 0.5,
-           fixedSize = TRUE, startsize = 480, initCex = 5, ...)
+           fixedSize = TRUE, startsize = 480, initCex = 5, 
+           margin = "", floating = FALSE, tag = "", ...)
 }
 \arguments{
   \item{x, y, z}{coordinates.  Any reasonable way of defining the
@@ -41,7 +42,9 @@ are cut off.  \code{initCex} is the size of text used
 to form the bitmap.  Increase this if letters look too blurry
 at the desired size.
 }
-
+  \item{margin, floating, tag}{
+\code{\link{material3d}} properties.
+  }
   \item{\dots}{
 Additional arguments to pass to  
 \code{\link[graphics]{text}} when drawing the text.
@@ -50,9 +53,8 @@ Additional arguments to pass to
 \note{
 The \code{\link{text3d}} function passes calls to this
 function if its \code{usePlotmath} argument is \code{TRUE}.
-The default value is determined by examining its
-\code{texts} argument; if it looks like an expression, 
-\code{plotmath3d} is used.
+This is the default value if its
+\code{texts} argument looks like an expression.
 }
 \value{
 Called for the side effect of displaying the sprites.


### PR DESCRIPTION
`plotmath3d` passed the new material properties to the string measuring functions, which led to warnings.