### PR TITLE
Save size even if window impl doesn't.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 0.108.40
+Version: 0.108.42
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 
-# rgl  0.108.40
+# rgl  0.108.42
 
 ## Major changes
 
@@ -99,6 +99,9 @@ colors properly (issue #212).
 * `bg3d(sphere = TRUE)` has been fixed (issue #207).
 * Textures were not appearing on spheres, and front-back
 differences weren't being rendered (issue #217).
+* When "knitting" within RStudio under R 4.2.0 on
+Windows, `rgl` scenes didn't appear (reported by
+Dieter Menne.) A workaround has been added.
 
 
 # rgl  0.108.3.2

--- a/src/RenderContext.h
+++ b/src/RenderContext.h
@@ -16,7 +16,7 @@ class RenderContext
 public:
   RenderContext()
   : subscene(0)
-  , rect(0,0,0,0)
+  , rect(0,0,256,256)
   , font(0)
   , time(0.0)
   , lastTime(0.0)

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -65,12 +65,13 @@ View::~View()
 // ---------------------------------------------------------------------------
 void View::setSize(int inWidth, int inHeight)
 {
+  /* record the size in case the Impl doesn't do anything */
+  resize(inWidth, inHeight);
   if ((windowImpl) && (flags & WINDOW_IMPL_OWNER)) {
     int left, top, right, bottom;
     windowImpl->getWindowRect(&left, &top, &right, &bottom);
     windowImpl->setWindowRect(left, top, left+inWidth, top+inHeight);
-  } else
-    resize(inWidth, inHeight);
+  }
 }
 // ---------------------------------------------------------------------------
 void View::setLocation(int inBaseX, int inBaseY)
@@ -208,6 +209,11 @@ void Window::bringToTop(int stay)
 // ---------------------------------------------------------------------------
 void Window::getWindowRect(int *in_left, int *in_top, int *in_width, int *in_height)
 {
+  /* Set defaults in case the impl doesn't do anything */
+  *in_left = 0;
+  *in_top = 0;
+  *in_width = width;
+  *in_height = height;
   windowImpl->getWindowRect(in_left, in_top, in_width, in_height);
 }
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This is a workaround for https://github.com/rstudio/rmarkdown-cookbook/issues/370 .