### PR TITLE
Don't remove the normals just because something is unlit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.0.9
+Version: 1.0.10
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl 1.0.9
+# rgl 1.0.10
 
 ## Major changes
 
@@ -33,6 +33,11 @@ auto printing.
 * If `transform3d()` or `rotate3d()` changed the orientation
 of a `mesh3d` object with normals, the normals ended up
 with the wrong sign. (Reported by Stephane Laurent.)
+* `scene3d()` (and hence `rglwidget()`) did not save
+the normals for unlit objects.  When the objects were
+also indexed, this prevented proper calculation of 
+front and back.  This is fixed, and a warning is
+issued if normals are not provided when needed.
 
 # rgl 1.0.1
 

--- a/R/convertScene.R
+++ b/R/convertScene.R
@@ -149,6 +149,11 @@ convertScene <- function(x = scene3d(minimal), width = NULL, height = NULL,
     result["is_twosided"] <- (type %in% c("quads", "surface", "triangles", "spheres", "bboxdeco") && 
       length(unique(c(mat$front, mat$back))) > 1) ||
       (type == "background" && obj$sphere)
+    if (result["is_twosided"] && !is.null(obj$indices)
+        && is.null(obj$normals)) {
+      warning("Object ", obj$id, " is two-sided and indexed.  It requires normals.")
+      result["is_twosided"] <- FALSE
+    }
     result["fixed_size"]  <- type == "text" || isTRUE(obj$fixedSize)
     result["rotating"] <- isTRUE(obj$rotating)
     result["fat_lines"]   <- mat$lwd != 1 && (result["is_lines"] || 

--- a/R/getscene.R
+++ b/R/getscene.R
@@ -26,9 +26,7 @@ scene3d <- function(minimal = TRUE) {
     attribs <- c("vertices", "colors", "texcoords", "dim",
           "texts", "cex", "adj", "radii", "ids",
           "usermatrix", "types", "offsets", "centers",
-          "family", "font", "pos", "axes", "indices")
-    if (lit || !minimal || type %in% c("light", "clipplanes", "planes"))
-      attribs <- c(attribs, "normals")
+          "family", "font", "pos", "axes", "indices", "normals")
     for (a in attribs) 
       if (rgl.attrib.count(id, a))
         result[[a]] <- rgl.attrib(id, a)

--- a/inst/htmlwidgets/lib/rglClass/init.src.js
+++ b/inst/htmlwidgets/lib/rglClass/init.src.js
@@ -910,7 +910,7 @@
       	f = fnew = obj.f[pass];
         pmode = obj.pmode[pass];
       	if (pmode === "culled")
-      	  f = [];
+      	  fnew = [];
         else if (pmode === "points") {
           // stay with default
         } else if ((type === "quads" || type === "text" ||


### PR DESCRIPTION
It will need them if two-sided and indexed, and maybe in some other cases.

Fixes #314 .