### PR TITLE
Get it to display in Jupyter.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.0.14
+Version: 1.0.15
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl 1.0.14
+# rgl 1.0.15
 
 ## Major changes
 
@@ -19,6 +19,8 @@ access to newer OpenGL functions in systems that support them.
 
 * The `texenvmap = TRUE` material property is now supported
 in WebGL.
+* The method of including shader source code
+has changed to work around a limitation in Jupyter.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ access to newer OpenGL functions in systems that support them.
 in WebGL.
 * The method of including shader source code
 has changed to work around a limitation in Jupyter.
+* The default C++ standard is now accepted, rather
+than requiring C++11.
 
 ## Bug fixes
 

--- a/R/rglwidget.R
+++ b/R/rglwidget.R
@@ -444,12 +444,19 @@ CanvasMatrixDependency <- makeDependency("CanvasMatrix4",
                                          package = "rgl",
                                          debugging = isTRUE(as.logical(Sys.getenv("RGL_DEBUGGING", "FALSE"))))
 
-shaders <- htmlPreserve(c('<script type = "text/plain" id = "rgl-vertex-shader">',
-             readLines(system.file("htmlwidgets/lib/rglClass/shaders/rgl_vertex.glsl", package = "rgl")),
-             '</script>',
-             '<script type = "text/plain" id = "rgl-fragment-shader">',
-             readLines(system.file("htmlwidgets/lib/rglClass/shaders/rgl_fragment.glsl", package = "rgl")),
-             '</script>'))
+local({
+  shaders <- c('rglwidgetClass.rgl_vertex_shader = function() {',
+               paste('return ',
+                 paste0('"', readLines(system.file("htmlwidgets/lib/rglClass/shaders/rgl_vertex.glsl", package = "rgl")), '\\n"', collapse = "+\n"),
+               ';};'),
+               'rglwidgetClass.rgl_fragment_shader = function() {',
+               paste('return ',
+                 paste0('"', readLines(system.file("htmlwidgets/lib/rglClass/shaders/rgl_fragment.glsl", package = "rgl")), '\\n"', collapse = "+\n"),
+               ';};'))
+  writeLines(paste(shaders, collapse = "\n"), 
+             file.path(system.file("htmlwidgets/lib/rglClass", package = "rgl"),
+                       "shadersrc.src.js"))
+})
 
 rglDependency <- makeDependency("rglwidgetClass", 
                       src = "htmlwidgets/lib/rglClass",
@@ -458,6 +465,7 @@ rglDependency <- makeDependency("rglwidgetClass",
                                  "buffer.src.js",
                                  "subscenes.src.js",
                                  "shaders.src.js",
+                                 "shadersrc.src.js",
                                  "textures.src.js",
                                  "projection.src.js",
                                  "mouse.src.js",
@@ -470,7 +478,6 @@ rglDependency <- makeDependency("rglwidgetClass",
                                  "pretty.src.js",
                                  "axes.src.js",
                                  "animation.src.js"),
-                      head = shaders,
                       stylesheet = "rgl.css",
                       package = "rgl",
                       debugging = isTRUE(as.logical(Sys.getenv("RGL_DEBUGGING", "FALSE"))))

--- a/inst/htmlwidgets/lib/rglClass/shaders.src.js
+++ b/inst/htmlwidgets/lib/rglClass/shaders.src.js
@@ -150,10 +150,10 @@
       );
 
       if (typeof vertex === "undefined")
-        vertex = document.getElementById("rgl-vertex-shader").text;
+        vertex = rglwidgetClass.rgl_vertex_shader();
         
       if (typeof fragment === "undefined") 
-        fragment = document.getElementById("rgl-fragment-shader").text;
+        fragment = rglwidgetClass.rgl_fragment_shader();
 
 //      console.log("vertex:");
 //      console.log(header + vertex);

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -15,7 +15,6 @@
 # 
 # Trying to make $(SHLIB)=rgl.so with no OpenGL.
 
-CXX_STD = CXX11
 PKG_CFLAGS=$(C_VISIBILITY)
 
 PKG_CPPFLAGS=@NULL_CPPFLAGS@

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,4 +1,3 @@
-CXX_STD = CXX11
 
 PKG_CPPFLAGS = \
 	-DHAVE_PNG_H -DHAVE_FREETYPE -Iext -Iext/ftgl -Iext/glad/include \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,6 @@
 VERSION = 2.10.4
 RWINLIB = ../windows/freetype-$(VERSION)
 
-CXX_STD = CXX11
-
 PKG_CPPFLAGS = \
 	-DHAVE_PNG_H -DHAVE_FREETYPE -Iext -Iext/ftgl \
 	-I$(RWINLIB)/include -I$(RWINLIB)/include/freetype2 \


### PR DESCRIPTION
Fixes Jupyter limitation: shaders are now stored in Javascript functions, not in the header of the page.  Fixes #329 .