### PR TITLE
Sync parameter names in implementation & declaration

### DIFF
--- a/src/BBoxDeco.h
+++ b/src/BBoxDeco.h
@@ -28,7 +28,7 @@ enum {
 
 struct AxisInfo {
   AxisInfo();
-  AxisInfo(int in_nticks, double* in_values, char** in_texts, int xlen, float xunit);
+  AxisInfo(int in_nticks, double* in_ticks, char** in_texts, int in_len, float in_unit);
   AxisInfo(AxisInfo& from);
   ~AxisInfo();
   void draw(RenderContext* renderContext, Vertex4& v, Vertex4& dir, Matrix4x4& modelview, 
@@ -50,10 +50,10 @@ typedef void (*userAxisPtr)(void *userData, int axis, int edge[3]);
 class BBoxDeco : public SceneNode 
 {
 public:
-  BBoxDeco(Material& in_material=defaultMaterial, AxisInfo& xaxis=defaultAxis, AxisInfo& yaxis=defaultAxis, AxisInfo& zaxis=defaultAxis, float marklen=15.0, bool marklen_fract=true,
+  BBoxDeco(Material& in_material=defaultMaterial, AxisInfo& in_xaxis=defaultAxis, AxisInfo& in_yaxis=defaultAxis, AxisInfo& in_zaxis=defaultAxis, float in_marklen_value=15.0, bool in_marklen_fract=true,
            float in_expand=1.0, bool in_front=false);
   void render(RenderContext* renderContext);
-  AABox getBoundingBox(const AABox& boundingBox) const;
+  AABox getBoundingBox(const AABox& in_bbox) const;
   Vertex getMarkLength(const AABox& boundingBox) const;
   int getAttributeCount(SceneNode* subscene, AttribID attrib);
   void getAttribute(SceneNode* subscene, AttribID attrib, int first, int count, double* result);

--- a/src/PrimitiveSet.h
+++ b/src/PrimitiveSet.h
@@ -73,18 +73,18 @@ protected:
   PrimitiveSet (
       Material& in_material, 
       int in_nvertices, 
-      double* vertex, 
+      double* in_vertices, 
       int in_type, 
       int in_nverticesperelement,
       bool in_ignoreExtent,
-      int in_nindices, 
+      int in_nindices,
       int* in_indices,
       bool in_bboxChange = false
   );
   PrimitiveSet(
-    Material& in_material,
+    Material& in_material, 
     int in_type,
-    int in_verticesperelement,
+    int in_nverticesperelement,
     bool in_ignoreExtent,
     bool in_bboxChange
   );
@@ -185,8 +185,8 @@ protected:
   
   FaceSet(
     Material& in_material, 
-    int in_type, 
-    int in_verticesperelement,
+    int in_type,
+    int in_nverticesperelement,
     bool in_ignoreExtent,
     bool in_bboxChange = false
   );
@@ -289,7 +289,7 @@ public:
 class LineStripSet : public PrimitiveSet
 {
 public:
-  LineStripSet(Material& material, int in_nvertex, double* in_vertex, bool in_ignoreExtent, 
+  LineStripSet(Material& in_material, int in_nvertices, double* in_vertex, bool in_ignoreExtent, 
                int in_nindices, int* in_indices, bool in_bboxChange = false);
   void drawPrimitive(RenderContext* renderContext, int index);
   /**

--- a/src/SphereSet.h
+++ b/src/SphereSet.h
@@ -16,7 +16,7 @@ private:
   bool          lastendcap; 
   bool          fastTransparency;
 public:
-  SphereSet(Material& in_material, int nsphere, double* center, int nradius, double* radius, 
+  SphereSet(Material& in_material, int in_ncenter, double* in_center, int in_nradius, double* in_radius,
             int in_ignoreExtent, bool in_fastTransparency);
   ~SphereSet();
 

--- a/src/Surface.h
+++ b/src/Surface.h
@@ -38,7 +38,7 @@ public:
    * location of individual items
    **/
   
-  virtual Vertex getPrimitiveCenter(int item) ;
+  virtual Vertex getPrimitiveCenter(int index) ;
 
   /**
    * begin sending items 

--- a/src/Viewpoint.h
+++ b/src/Viewpoint.h
@@ -56,8 +56,8 @@ public:
   void        setZoom(const float zoom);
   float       getFOV(void) const;
   void        setFOV(const float in_fov);
-  void        setupFrustum(RenderContext* rctx, const Sphere& viewvolumeSphere);
-  void        setupProjMatrix(RenderContext* rctx, const Sphere& viewvolumeSphere);
+  void        setupFrustum(RenderContext* rctx, const Sphere& viewSphere);
+  void        setupProjMatrix(RenderContext* rctx, const Sphere& viewSphere);
   Vertex      getObserver();
   void	      setObserver(bool automatic, Vertex in_eye);
   void	      setupViewer(RenderContext* rctx);

--- a/src/api.h
+++ b/src/api.h
@@ -99,8 +99,8 @@ void rgl_locator(int* successptr, double* locations);
 
 void rgl_selectstate(int* dev, int* sub, int* successptr, int* selectstate, double* locations);
 void rgl_setselectstate(int* dev, int* sub, int* successptr, int *idata);
-void rgl_setEmbeddings(int* successptr, int* embeddings);
-void rgl_getEmbeddings(int* successptr, int* embeddings);
+void rgl_setEmbeddings(int* id, int* embeddings);
+void rgl_getEmbeddings(int* id, int* embeddings);
 
 SEXP rgl_setMouseCallbacks(SEXP button, SEXP begin, SEXP update, SEXP end, SEXP dev, SEXP sub);
 SEXP rgl_setWheelCallback(SEXP rotate, SEXP dev, SEXP sub);

--- a/src/geom.h
+++ b/src/geom.h
@@ -26,7 +26,7 @@ public:
   void operator += (const AABox& aabox);
   void operator += (const Sphere& sphere);
   void operator += (const Vertex& vertex);
-  bool operator < (const AABox& aabox) const;
+  bool operator < (const AABox& that) const;
   AABox transform(Matrix4x4& M);
   Vertex getCenter(void) const;
   Vertex vmin, vmax;
@@ -43,8 +43,8 @@ public:
   Sphere() : center(0,0,0), radius(1) {};
   Sphere(const Vertex& center, const float radius);
   Sphere(const float radius);
-  Sphere(const AABox& aabox);
-  Sphere(const AABox& aabox, const Vertex& scale);
+  Sphere(const AABox& bbox);
+  Sphere(const AABox& bbox, const Vertex& s);
   Vertex center;
   float radius;
 };

--- a/src/glgui.h
+++ b/src/glgui.h
@@ -90,10 +90,10 @@ public:
 
   void draw(const char* text, int length, 
             double adjx, double adjy, double adjz,
-            int draw, const RenderContext& rc);
+            int pos, const RenderContext& rc);
   void draw(const wchar_t* text, int length, 
             double adjx, double adjy, double adjz,
-            int draw, const RenderContext& rc); 
+            int pos, const RenderContext& rc); 
   double width(const char* text);
   double width(const wchar_t* text);
   double height();

--- a/src/gui.h
+++ b/src/gui.h
@@ -203,7 +203,7 @@ public:
 
   void bringToTop(int stay);
   void setWindowRect(int left, int top, int right, int bottom);
-  void getWindowRect(int *left, int *top, int *right, int *bottom);
+  void getWindowRect(int *in_left, int *in_top, int *in_width, int *in_height);
   void getFonts(FontArray& outfonts, int nfonts, char** family, int* style, double* cex,
                 bool useFreeType);
 

--- a/src/rglmath.h
+++ b/src/rglmath.h
@@ -96,9 +96,9 @@ struct Vec3
   }
   void normalize();
   Vec3 cross(Vec3 op2) const;
-  float angle(const Vec3& op2) const;
-  float operator * (Vec3 op2);
-  Vec3 operator * (float value);
+  float angle(const Vec3& that) const;
+  float operator * (Vec3 v);
+  Vec3 operator * (float s);
   Vec3 operator+(Vec3 op2) const;
   Vec3 operator-(Vec3 op2) const;
   Vec3 scale(const Vec3& op2) const;
@@ -131,9 +131,9 @@ struct Vec4
   Vec4(const Normal& n, float in_w=0.0f) : x(n.x), y(n.y), z(n.z), w(in_w) {};
   Vec4() {};
   Vec4(const float x, const float y, const float z, const float w=1.0f);
-  float operator * (const Vec4& op2) const;
-  Vec4 operator * (const float value) const;
-  Vec4 operator + (const Vec4& op2) const;
+  float operator * (const Vec4& v) const;
+  Vec4 operator * (const float s) const;
+  Vec4 operator + (const Vec4& v) const;
   bool   missing() const;  /* Any components missing */
   float& operator[](int i);
   static inline Vec4& asVec4(float* ptr) {
@@ -147,8 +147,8 @@ public:
   Matrix4x4();
   Matrix4x4(const Matrix4x4& src);
   Matrix4x4(const double*);
-  Vec3 operator*(const Vec3 op2) const;
-  Vec4 operator*(const Vec4& op2) const;
+  Vec3 operator*(const Vec3 v) const;
+  Vec4 operator*(const Vec4& v) const;
   Matrix4x4 operator*(const Matrix4x4& op2) const;
   Vec4 getRow(int row);
   void setIdentity(void);


### PR DESCRIPTION
e.g. for `AxisInfo::AxisInfo`:

https://github.com/dmurdoch/rgl/blob/ae9f14d6307ebf9dd2857d6bde2dd26f8aef2f81/src/BBoxDeco.cpp#L135

https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html