### PR TITLE
Remove superfluous top-level const qualifications

### DIFF
--- a/src/PrimitiveSet.h
+++ b/src/PrimitiveSet.h
@@ -57,7 +57,7 @@ public:
   /**
    * set a vertex
    **/
-  const void setVertex(int index, double* v) { vertexArray.setVertex(index, v); }
+  void setVertex(int index, double* v) { vertexArray.setVertex(index, v); }
 
   /**
    * setup all vertices

--- a/src/SceneNode.h
+++ b/src/SceneNode.h
@@ -65,8 +65,8 @@ typedef unsigned int AttribID;
 class SceneNode
 {
 public:
-  inline const TypeID getTypeID() const { return typeID; }
-  inline const ObjID getObjID() const { return objID; }
+  inline TypeID getTypeID() const { return typeID; }
+  inline ObjID getObjID() const { return objID; }
   virtual ~SceneNode() { };
   static ObjID nextID;
   SceneNode *owner;  /* don't delete this node while the owner is non-NULL */

--- a/src/Shape.h
+++ b/src/Shape.h
@@ -50,7 +50,7 @@ public:
    * does this shape change dimensions according to the way it is rendered?
    * if so, the above is just a guess...
    **/
-  const bool getBBoxChanges() const { return bboxChanges; }
+  bool getBBoxChanges() const { return bboxChanges; }
 
   /**
    * this shows how the shape would be sized in the given context
@@ -62,7 +62,7 @@ public:
    **/
   Material* getMaterial()  { return &material; }
   
-  const bool getIgnoreExtent() const { return ignoreExtent; }
+  bool getIgnoreExtent() const { return ignoreExtent; }
 
   virtual void getTypeName(char* buffer, int buflen) { strncpy(buffer, "shape", buflen); };
   
@@ -119,9 +119,9 @@ public:
    */
   virtual Shape* get_shape(int id) { return NULL; }
   
-  const bool isTransparent() const { return transparent; }
+  bool isTransparent() const { return transparent; }
   
-  const bool isBlended() const { return blended; }
+  bool isBlended() const { return blended; }
   
   /**
    * Does this shape need to go at the head of the shape list, rather than the tail?

--- a/src/Viewpoint.h
+++ b/src/Viewpoint.h
@@ -53,9 +53,9 @@ public:
 
   UserViewpoint(float fov=90.0f, float zoom=1.0f);
   float       getZoom(void) const; 
-  void        setZoom(const float zoom);
+  void        setZoom(float zoom);
   float       getFOV(void) const;
-  void        setFOV(const float in_fov);
+  void        setFOV(float in_fov);
   void        setupFrustum(RenderContext* rctx, const Sphere& viewvolumeSphere);
   void        setupProjMatrix(RenderContext* rctx, const Sphere& viewvolumeSphere);
   Vertex      getObserver();

--- a/src/geom.h
+++ b/src/geom.h
@@ -41,8 +41,8 @@ public:
 class Sphere {
 public:
   Sphere() : center(0,0,0), radius(1) {};
-  Sphere(const Vertex& center, const float radius);
-  Sphere(const float radius);
+  Sphere(const Vertex& center, float radius);
+  Sphere(float radius);
   Sphere(const AABox& aabox);
   Sphere(const AABox& aabox, const Vertex& scale);
   Vertex center;

--- a/src/rglmath.h
+++ b/src/rglmath.h
@@ -130,9 +130,9 @@ struct Vec4
 
   Vec4(const Normal& n, float in_w=0.0f) : x(n.x), y(n.y), z(n.z), w(in_w) {};
   Vec4() {};
-  Vec4(const float x, const float y, const float z, const float w=1.0f);
+  Vec4(float x, float y, float z, float w=1.0f);
   float operator * (const Vec4& op2) const;
-  Vec4 operator * (const float value) const;
+  Vec4 operator * (float value) const;
   Vec4 operator + (const Vec4& op2) const;
   bool   missing() const;  /* Any components missing */
   float& operator[](int i);
@@ -147,12 +147,12 @@ public:
   Matrix4x4();
   Matrix4x4(const Matrix4x4& src);
   Matrix4x4(const double*);
-  Vec3 operator*(const Vec3 op2) const;
+  Vec3 operator*(Vec3 op2) const;
   Vec4 operator*(const Vec4& op2) const;
   Matrix4x4 operator*(const Matrix4x4& op2) const;
   Vec4 getRow(int row);
   void setIdentity(void);
-  void setRotate(const int axis, const float degree);
+  void setRotate(int axis, float degree);
   void getData(double* dest);
   void loadData(const double* from);
   void loadData(const float* from);


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html and https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html which flagged these