### PR TITLE
If ARIA label is not included, don't crash.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.2.2
+Version: 1.2.3
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,13 @@
-# rgl 1.2.2
+# rgl 1.2.3
 
 ## Minor changes
 
 * ARIA support now declares `rgl` scenes with `role = "img"`.
+
+## Bug fixes
+
+* The ARIA support didn't work with `htmlwidgets::saveWidget()` when
+run in a Shiny session.
 
 # rgl 1.2.1
 

--- a/R/rglwidget.R
+++ b/R/rglwidget.R
@@ -402,8 +402,14 @@ ariaLabelId <- function(id)
   paste0(id, "-aria")
 
 widget_html.rglWebGL <- function(id, style, class, ...){
-  tags$div(id = id, style = style, class = class, role = "img",
+  result <- tags$div(id = id, style = style, class = class, role = "img",
            "aria-labelledby" = ariaLabelId(id))
+  # In shiny, we need to write the alt text label.
+  if (inShiny())
+    result <- tags$div(tags$p("3D plot 1", id = ariaLabelId(id),
+                                                 hidden = NA),
+                       result)
+  result
 }
 
 print.rglMouseSelection <- function(x, verbose = FALSE, ...) {

--- a/inst/htmlwidgets/lib/rglClass/init.src.js
+++ b/inst/htmlwidgets/lib/rglClass/init.src.js
@@ -1223,10 +1223,12 @@
       newcanvas.setAttribute("aria-labelledby", 
         labelid);
         
-      if (typeof this.scene.altText !== "undefined")
+      if (typeof this.scene.altText !== "undefined") {
         // We're in Shiny, so alter the label
-        document.getElementById(labelid).innerHTML = this.scene.altText;
-
+        var label = document.getElementById(labelid);
+        if (label)
+          label.innerHTML = this.scene.altText;
+      }
       newcanvas.addEventListener("webglcontextrestored",
         this.onContextRestored, false);
       newcanvas.addEventListener("webglcontextlost",


### PR DESCRIPTION
Try to include it when saveWidget is used in Shiny.

Bug was reported here:  https://stackoverflow.com/q/76784252