### PR TITLE
Passing cex argument to plotmath3d in text3d

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.2.3
+Version: 1.2.4
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl 1.2.3
+# rgl 1.2.4
 
 ## Minor changes
 
@@ -8,6 +8,8 @@
 
 * The ARIA support caused `htmlwidgets::saveWidget()` to fail when
 run in a Shiny session.
+* `text3d()` and `mtext3d()` did not pass the `cex` argument to 
+`plotmath3d()` (pull request #384).
 
 # rgl 1.2.1
 

--- a/R/r3d.rgl.R
+++ b/R/r3d.rgl.R
@@ -496,7 +496,7 @@ text3d      <- function(x, y = NULL, z = NULL,
 			...) {
   if (usePlotmath) 
     return(plotmath3d(x = x, y = y, z = z, text = texts, adj = adj, 
-                      pos = pos, offset = offset, ...))
+                      pos = pos, offset = offset, cex = cex, ...))
   .check3d(); save <- material3d(); on.exit(material3d(save))
   do.call("rgl.material0", .fixMaterialArgs(..., Params = save))
   # Force evaluation


### PR DESCRIPTION
This fixes a bug causing `cex` argument to `text3d` and `mtext3d` to be ineffective when text is an `expression(...)`.
