### PR TITLE
Missed passing target to recursive search.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.2.13
+Version: 1.2.15
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl 1.2.14
+# rgl 1.2.15
 
 ## Major changes
 
@@ -29,6 +29,9 @@ run in a Shiny session.
 * Smooth shapes were not rendered correctly by `rglwidget()`.
   This was especially noticeable for spheres with `fov = 0`, but was present in other cases as well (issue #401).
 * `textype = "alpha"` was not rendered correctly by `rglwidget()` (issue #408).
+* `setUserCallbacks()` and related functions failed when
+the `subscene` argument was anything other than the root
+subscene.
 
 # rgl 1.2.1
 

--- a/R/setUserCallbacks.R
+++ b/R/setUserCallbacks.R
@@ -6,7 +6,7 @@ findSubscene <- function(subscene, id) {
   subscenes <- subscene$subscenes
   if (!is.null(subscenes)) {
     for (i in seq_along(subscenes)) {
-      if (!is.null(result <- findSubscene(subscenes[[i]])))
+      if (!is.null(result <- findSubscene(subscenes[[i]], id)))
         return(result)
     }
   }


### PR DESCRIPTION
Fixes an issue with `setUserCallback()` on a subscene.