### PR TITLE
skip uname calls under macOS

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -46,9 +46,13 @@
   
   unixos <- "none"
   if (.Platform$OS.type == "unix") {
-    unixos <- system("uname", intern=TRUE)
-    if (!length(unixos))
-      unixos <- "unknown"    
+    if (Sys.info()["sysname"] == "Darwin") {
+      unixos <- "Darwin"
+    } else {
+      unixos <- system("uname", intern=TRUE)
+      if (!length(unixos))
+        unixos <- "unknown"
+    }
   }
   
   dll <- try(dyn.load(dynlib <- getDynlib(dir)))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -154,7 +154,7 @@
 setGraphicsDelay <- function(delay = Sys.getenv("RGL_SLOW_DEV", 0), 
                              unixos = "none") {
   if (unixos == "Darwin") {
-    version <- try(numeric_version(system("uname -r", intern = TRUE)))
+    version <- try(numeric_version(Sys.info()['release']))
     if (missing(delay) &&
         !inherits(version, "try-error") && 
         !is.na(version) && 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -154,7 +154,7 @@
 setGraphicsDelay <- function(delay = Sys.getenv("RGL_SLOW_DEV", 0), 
                              unixos = "none") {
   if (unixos == "Darwin") {
-    version <- try(numeric_version(Sys.info()['release']))
+    version <- try(numeric_version(Sys.info()["release"]))
     if (missing(delay) &&
         !inherits(version, "try-error") && 
         !is.na(version) && 


### PR DESCRIPTION
some of our macOS R environments have bespoke path configurations, such that `system("uname")` fails ... and i figured `rgl` doesn't really need to make these calls anyway.

(i did wonder if the value of `Sys.info()["sysname"]` could be assigned directly to `unixos` [ditching calls to uname under non-darwin unix too], but wasn't 100% sure there wasn't some behaviour i didn't know about).