### PR TITLE
If device init fails, need to set options(rgl.useNULL = TRUE), because

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -119,11 +119,11 @@
   
   if (!ret) {
     warning("'rgl.init' failed, will use the null device.\nSee '?rgl.useNULL' for ways to avoid this warning.", call. = FALSE)
-    onlyNULL <- TRUE
+    options(rgl.useNULL = TRUE)
     rgl.init(initValue, TRUE)	
   }
 
-  if (!rgl.useNULL() && !onlyNULL) 
+  if (!rgl.useNULL()) 
     setGraphicsDelay(unixos = unixos)
   
   # Are we running in reprex::reprex?  If so, do


### PR DESCRIPTION
rgl.useNULL() looks there.

Fixes #448