### PR TITLE
rgl support for litedown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.3.21
+Version: 1.3.22
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),
@@ -32,10 +32,11 @@ Suggests: MASS, rmarkdown (>= 2.16), deldir (>= 1.0-4), orientlib, lattice, misc
           magick, plotrix (>= 3.7-3), tripack, interp, alphashape3d, tcltk,
           js (>= 1.2), webshot2 (>= 0.1.0), downlit (>= 0.4.0), pkgdown (>= 2.0.0), extrafont,
           shiny, manipulateWidget (>= 0.9.0), testthat,
-          crosstalk, V8, chromote, jpeg, png, markdown
+          crosstalk, V8, chromote, jpeg, png, markdown,
+          litedown (>= 0.7.1), xfun
 Imports: graphics, grDevices, stats, utils, 
          htmlwidgets (>= 1.6.0), htmltools, knitr (>= 1.33), jsonlite (>= 0.9.20),
-         magrittr, R6, base64enc, mime
+         magrittr, R6, base64enc, mime, vctrs
 Enhances: waldo
 Description: Provides medium to high level functions for 3D interactive graphics, including
     functions modelled on base graphics (plot3d(), etc.) as well as functions for

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,3 +56,6 @@ VignetteBuilder: knitr, rmarkdown
 Biarch: true
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
+Remotes: 
+  dmurdoch/litedown@htmlwidgets,
+  dmurdoch/htmlwidgets@litedown

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,7 +12,8 @@ export(.check3d,
   contourLines3d,
   cube3d, cuboctahedron3d, cur3d, 
   currentSubscene3d, cylinder3d,
-  decorate3d, deform.mesh3d, delFromSubscene3d, divide.mesh3d, dodecahedron3d, dot3d, drape3d, ellipse3d, 
+  decorate3d, deform.mesh3d, delFromSubscene3d, divide.mesh3d, dodecahedron3d, 
+  dot3d, drape3d, ellipse3d, 
   expect_known_scene, extrude3d,
   facing3d, figWidth, figHeight, filledContour3d,
   gc3d, getBoundary3d,
@@ -48,8 +49,8 @@ export(.check3d,
   rgl.setAxisCallback, rgl.setMouseCallbacks, rgl.setWheelCallback,
   safe.dev.off,
   set3d, setAxisCallbacks, setGraphicsDelay, setupKnitr, 
+  setupLitedown, 
   setUserCallbacks, setUserShaders, shade3d, shadow3d,
-
   shapelist3d, shinyGetPar3d, shinySetPar3d, shinyResetBrush, 
   show2d, snapshot3d, 
   spheres3d, spin3d, sprites3d, subdivision3d, 
@@ -178,6 +179,7 @@ export(.check3d,
  importFrom(utils, capture.output, count.fields, file_test, 
             flush.console, packageVersion, read.table, head, tail)
  importFrom(R6, R6Class)
+ importFrom(vctrs, s3_register)
  
 # These were in rglwidget
  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
-# rgl 1.3.21
+# rgl 1.3.22
 
 * The `shapelist3d()` function did not handle material names
 properly (issue #462).
 * The `markdown` package no longer supports `rgl`, so the change
 in `rgl` 1.3.1 to use it has been reverted.  This means Pandoc
 is once again necessary to build the vignettes.
+* Experimental support for the `litedown` package has been added.
+This is still work-in-progress, and not all features are supported.
+It requires unreleased versions of both `litedown` and `htmlwidgets`
+packages.
 
 # rgl 1.3.18
 

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -178,6 +178,9 @@ fns <- local({
                          rgl.newwindow = autoprint,
                          rgl.closewindows = autoprint) {
     
+    if (!in_knitr() && isNamespaceLoaded("litedown"))
+      return(setupLitedown(autoprint))
+    
     # R produces multiple vignettes in the same session.
     # Watch out for leftovers
     
@@ -289,7 +292,13 @@ figWidth <- function() {
     return(pkgdown_dims()$width)
   else if (in_knitr())
     opts <- opts_current$get(c("fig.width", "dpi", "fig.retina"))
-  else
+  else if (in_litedown()) {
+    opts <- as.list(litedown::reactor(c("fig.width", "dpi", "fig.retina")))
+    if (is.null(opts$dpi))
+      opts$dpi <- 84
+    if (is.null(opts$fig.retina))
+      opts$fig.retina <- 1
+  } else
     opts <- NULL
   if (length(opts)) {
     result <- with(opts, fig.width*dpi/fig.retina)
@@ -302,7 +311,13 @@ figHeight <- function() {
     return(pkgdown_dims()$height)
   else if (in_knitr())
     opts <- opts_current$get(c("fig.height", "dpi", "fig.retina"))
-  else
+  else if (in_litedown()) {
+    opts <- as.list(litedown::reactor(c("fig.height", "dpi", "fig.retina")))
+    if (is.null(opts$dpi))
+      opts$dpi <- 84
+    if (is.null(opts$fig.retina))
+      opts$fig.retina <- 1
+  } else
     opts <- NULL
   if (length(opts)) {
     result <- with(opts, fig.height*dpi/fig.retina)

--- a/R/litedown.R
+++ b/R/litedown.R
@@ -1,0 +1,142 @@
+
+in_litedown <- function() 
+  isNamespaceLoaded("litedown") && isTRUE(litedown::reactor("rgl.inLitedown"))
+
+fns <- local({
+  saveopts <- NULL
+  plotnum <- 0
+  setupDone <- NULL
+  latex <- FALSE
+  previd <- "None"
+  
+  counter <- 0L
+  
+  rgl_counter <- function() {
+    counter <<- counter + 1L
+    counter
+  }
+  
+  litedownNeedsSnapshot <- function(options){
+    litedown::get_context("format") != "html"
+  }
+  
+  setupLitedown <- function(autoprint = FALSE) {
+    if (!requireNamespace("litedown"))
+      return()
+    
+    s3_register("xfun::record_print", "rglOpen3d")
+    s3_register("xfun::record_print", "rglId")
+    
+    litedown::reactor(rgl.inLitedown = TRUE)
+
+    # R produces multiple vignettes in the same session.
+    # Watch out for leftovers
+    
+    if (!is.null(setupDone)) {
+      options(saveopts)
+      saveopts <<- NULL
+      counter <<- 0L
+    }
+    
+    setupDone <<- list(autoprint = autoprint)
+    
+    litedown::reactor(rgl.chunk = TRUE)
+    
+    latex <<- identical(litedown::get_context("format"), "latex")
+    if (autoprint)
+      saveopts <<- litedown::reactor(rgl.printRglwidget = TRUE)
+  }  
+  
+  record_print.rglOpen3d <- function(x, ...) {
+    print(x, ...)
+    if (isTRUE(litedown::reactor("rgl.printRglwidget"))) {
+      plotnum <<- plotnum + 1
+    }
+    invisible(x)
+  }
+
+  record_print.rglId <- function(x, ...) {
+    if (!isTRUE(litedown::reactor("rgl.printRglwidget")) || par3d("skipRedraw"))	
+      invisible("")
+    options <- litedown::reactor()
+    scene <- scene3d()
+    args <- list(...)
+    if (inherits(x, "rglHighlevel"))
+      plotnum <<- plotnum + 1
+    
+    recorded <- structure(list(plotnum = plotnum,
+                     scene = scene,
+                     options = options),
+                class = c("rglRecordedplot", "knit_other_plot"))
+
+    doSnapshot <- litedownNeedsSnapshot(options)
+    margin <- options$rgl.margin
+    if (is.null(margin))
+      margin <- 100
+    content <- suppressMessages(rglwidget(scene,
+                         width = figWidth() + margin,
+                         height = figHeight(),
+                         webgl = !doSnapshot))
+    if (inherits(content, "knit_image_paths")) {
+      # # We've done a snapshot, put it in the right place.
+      name <- fig_path("-rgl.png", options, rgl_counter())
+      if (!file_test("-d", dirname(name)))
+        dir.create(dirname(name), recursive = TRUE)
+      file.copy(content, name, overwrite = TRUE)
+      unlink(content)
+      alt <- options$fig.alt
+      if (is.null(alt))
+        alt <- options$fig.cap
+      if (is.null(alt))
+        alt <- ""
+      xfun::new_record(sprintf("![%s](%s)", alt, name), "asis")
+    } else {
+      id <- content$elementId
+      fig.align <- options$fig.align
+      if (length(fig.align) ==  1 && fig.align != "default")
+        content <- prependContent(content,
+                                  tags$style(sprintf(
+                                    "#%s {%s}",
+                                    content$elementId,
+                                    switch(fig.align,
+                                           center = "margin:auto;",
+                                           left   = "margin-left:0;margin-right:auto;",
+                                           right  = "margin-left:auto;margin-right:0;",
+                                           ""))))
+      result <- do.call(xfun::record_print, c(list(x = content, options = options), args))
+      if (!latex) {
+        meta <- litedown::reactor("meta")
+        rgldata <- meta$"header-includes"
+        if (is.null(rgldata))
+          rgldata <- character()
+        if (inherits(x, "rglLowlevel")) {
+          rgldata[previd] <- sprintf('<script type="application/json" data-for="%s">{"x":[],"evals":[],"jsHooks":[]}</script>', previd)
+        }
+        # FIXME:  this isn't the right way to do this...
+        regexp <- "^<!--html_preserve-->(<p id.*></div>)\n(<script.*</script>)<!--/html_preserve-->$"
+        insert <- sub(regexp, "\\1", result)
+        data <- sub(regexp, "\\2", result)
+        
+        rgldata <- c(rgldata, data)
+        names(rgldata)[length(rgldata)] <- id
+        previd <<- id
+      }
+      
+      meta$"header-includes" <- rgldata
+      litedown::reactor(meta = meta)
+      
+      xfun::new_record(insert, "asis")
+    }
+  }
+  
+  list(
+    setupLitedown = setupLitedown,
+    record_print.rglOpen3d = record_print.rglOpen3d,
+    record_print.rglId = record_print.rglId)
+})
+
+setupLitedown <- fns[["setupLitedown"]]
+record_print.rglId <- fns[["record_print.rglId"]]
+record_print.rglOpen3d <- fns[["record_print.rglOpen3d"]]
+
+rm(fns)

--- a/man/setupKnitr.Rd
+++ b/man/setupKnitr.Rd
@@ -3,21 +3,26 @@
 \alias{hook_webgl}
 \alias{hook_rglchunk}
 \alias{setupKnitr}
+\alias{setupLitedown}
 \title{
-Displaying RGL scenes in \pkg{knitr} documents
+Displaying RGL scenes in \pkg{knitr} or \pkg{liteDown} documents
 }
 \description{
 These functions allow RGL graphics to be embedded in \pkg{knitr}
-documents.
+and \pkg{litedown} documents.
 
 The simplest method is to run \code{setupKnitr(autoprint = TRUE)}
+or \code{setupLitedown(autoprint = TRUE)}
 early in the document.  That way RGL commands act a lot
 like base graphics commands:  plots will be automatically inserted
-where appropriate, according to the \code{fig.keep} chunk option.
+where appropriate.  In \pkg{knitr}, this is according to the 
+\code{fig.keep} chunk option.
 By default (\code{fig.keep = "high"}), only high-level plots
 are kept, after low-level changes have been merged into them.
 See the \pkg{knitr} documentation 
 \url{https://yihui.org/knitr/options/#plots} for more details.
+In \pkg{litedown}, \code{fig.keep} is ignored and behaviour
+always follows the \code{fig.keep = "high"} rules.
 To suppress auto-printing, the RGL calls
 can be wrapped in \code{\link{invisible}()}.  
 Similarly to \pkg{grid} graphics (used by \pkg{lattice}
@@ -28,7 +33,8 @@ packages, auto-printing is the only way to get this to
 work:  calling \code{\link{print}} explicitly doesn't
 work.
 
-Other functions allow embedding either as bitmaps (\code{hook_rgl} with format \code{"png"}),
+In \pkg{knitr} (but not \pkg{litedown}),
+other functions allow embedding either as bitmaps (\code{hook_rgl} with format \code{"png"}),
 fixed vector graphics (\code{hook_rgl} with format \code{"eps"}, \code{"pdf"} or
 \code{"postscript"}), or interactive WebGL graphics (\code{hook_webgl}).  \code{hook_rglchunk} is not normally invoked by the 
 user; it is the hook that supports automatic creation and 
@@ -53,6 +59,7 @@ in a code chunk if the example prints RGL objects.
 setupKnitr(autoprint = FALSE,
            rgl.newwindow = autoprint,
            rgl.closewindows = autoprint)
+setupLitedown(autoprint = FALSE)
 hook_rgl(before, options, envir)
 hook_webgl(before, options, envir)
 hook_rglchunk(before, options, envir)
@@ -72,6 +79,10 @@ The \code{setupKnitr()} function needs to be called once
 at the start of the document to install the \pkg{knitr} hooks.
 If it is called twice in the same session the second call 
 will override the first.
+
+If \code{setupKnitr()} is called in a \pkg{litedown} document,
+it will pass \code{autoprint} to \code{setupLitedown()}.  The reverse
+is not true.
 
 The following chunk options are supported:
 \itemize{
@@ -109,6 +120,9 @@ to successive plots within the chunk.
 (This is due to a limitation in \pkg{knitr}, and may
 change in the future.)
 }
+In \pkg{litedown}, only \code{dpi}, \code{fig.align}, 
+\code{fig.retina}, \code{fig.width}, \code{fig.height} and 
+\code{rgl.margin} are respected.
 }
 \value{
 A string to be embedded into the output, or \code{NULL} if called


### PR DESCRIPTION
Adds support for litedown from rgl.

Currently needs unreleased versions of litedown and htmlwidgets:
```
remotes::install_github("dmurdoch/litedown@htmlwidgets")
remotes::install_github("dmurdoch/htmlwidgets@litedown")
```
See https://github.com/yihui/litedown/pull/86 and https://github.com/ramnathv/htmlwidgets/pull/493