### PR TITLE
Use `par3d("cex")` rather than `par("cex")` to avoid opening a base g…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rgl
-Version: 1.3.26
+Version: 1.3.27
 Title: 3D Visualization Using OpenGL
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
-# rgl 1.3.26
+# rgl 1.3.27
 
 * Support for classes defined in the `tripack` package
 has been dropped at the request of CRAN.
 * Added the `latex3d()` function to draw LaTeX text using the
 `xdvir` package.
+* Both `plotmath3d()` and `latex3d()` now use default
+`cex = par3d("cex")`.
 
 # rgl 1.3.24
 

--- a/R/latex3d.R
+++ b/R/latex3d.R
@@ -1,6 +1,6 @@
 latex3d <- function(x, y = NULL, z = NULL,
 		       text, 
-		       cex = par("cex"), adj = 0.5,
+		       cex = par3d("cex"), adj = 0.5,
 		       pos = NULL, offset = 0.5,
 		       fixedSize = TRUE,
 		       startsize = 480, initCex = 5, 

--- a/R/plotmath3d.R
+++ b/R/plotmath3d.R
@@ -1,6 +1,6 @@
 plotmath3d <- function(x, y = NULL, z = NULL,
 		       text, 
-		       cex = par("cex"), adj = 0.5,
+		       cex = par3d("cex"), adj = 0.5,
 		       pos = NULL, offset = 0.5,
 		       fixedSize = TRUE,
 		       startsize = 480, initCex = 5, 

--- a/man/plotmath3d.Rd
+++ b/man/plotmath3d.Rd
@@ -12,11 +12,11 @@ file as a texture in a sprite.  \code{latex3d} uses the
 the same approach to display it in \pkg{rgl}.
 }
 \usage{
-plotmath3d(x, y = NULL, z = NULL, text, cex = par("cex"),
+plotmath3d(x, y = NULL, z = NULL, text, cex = par3d("cex"),
            adj = 0.5, pos = NULL, offset = 0.5,
            fixedSize = TRUE, startsize = 480, initCex = 5, 
            margin = "", floating = FALSE, tag = "", ...)
-latex3d(x, y = NULL, z = NULL, text, cex = par("cex"), 
+latex3d(x, y = NULL, z = NULL, text, cex = par3d("cex"), 
            adj = 0.5, pos = NULL, offset = 0.5,
            fixedSize = TRUE, startsize = 480, initCex = 5, 
            margin = "", floating = FALSE, tag = "", 


### PR DESCRIPTION
…raphics window.