### PR TITLE
Don't double-free mat.texture

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1044,6 +1044,7 @@ void rgl::rgl_material(int *successptr, int* idata, char** cdata, double* ddata)
                               mat.mipmap, mat.minfilter, mat.magfilter, mat.envmap,
                               deleteFile);
     if ( !mat.texture->isValid() ) {
+      // delete mat.texture;
       mat.texture = NULL;
     } else
       mat.alphablend = mat.alphablend || mat.texture->hasAlpha();

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1044,8 +1044,6 @@ void rgl::rgl_material(int *successptr, int* idata, char** cdata, double* ddata)
                               mat.mipmap, mat.minfilter, mat.magfilter, mat.envmap,
                               deleteFile);
     if ( !mat.texture->isValid() ) {
-      mat.texture->unref();
-      // delete mat.texture;
       mat.texture = NULL;
     } else
       mat.alphablend = mat.alphablend || mat.texture->hasAlpha();


### PR DESCRIPTION
`mat.texture = NULL` itself does `mat.texture->unref()`:

https://github.com/dmurdoch/rgl/blob/8b32d9cd3996ceb03785c1181d0f7b7c0e8a8ae4/src/types.h#L63

So this is actually a double-free.

This was flagged by [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) on `clang`.