### PR TITLE
Skip View::update() on drag/release when mouse mode is mmUSER

### DIFF
--- a/src/rglview.cpp
+++ b/src/rglview.cpp
@@ -187,11 +187,14 @@ void RGLView::mouseMove(int mouseX, int mouseY)
     mouseX = clamp(mouseX, 0, vwidth-1);
     mouseY = clamp(mouseY, 0, vheight-1);
     if (windowImpl->beginGL()) {
-      subscene->buttonUpdate(subscene->drag, mouseX, mouseY);
-      windowImpl->endGL();
-      
-      View::update();
-    }
+  MouseModeID rgl_mouse_mode = subscene->getMouseMode(subscene->drag);
+  subscene->buttonUpdate(subscene->drag, mouseX, mouseY);
+  windowImpl->endGL();
+
+  if (rgl_mouse_mode != mmUSER) {
+    View::update();
+  }
+}
   } else {
     ModelViewpoint* modelviewpoint = scene->getCurrentSubscene()->getModelViewpoint();
     if ( modelviewpoint->isInteractive() ) {
@@ -200,8 +203,12 @@ void RGLView::mouseMove(int mouseX, int mouseY)
       if (subscene && subscene->getMouseMode(bnNOBUTTON) != mmNONE) {
         subscene->translateCoords(&mouseX, &mouseY);
         subscene->drag = bnNOBUTTON;
-        subscene->buttonUpdate(bnNOBUTTON, mouseX, mouseY);
-        View::update();
+MouseModeID rgl_mouse_mode = subscene->getMouseMode(bnNOBUTTON);
+subscene->buttonUpdate(bnNOBUTTON, mouseX, mouseY);
+
+if (rgl_mouse_mode != mmUSER) {
+  View::update();
+}
       }
     }
   }


### PR DESCRIPTION
Hi! 

I'm the maintainer of the [rTwig](https://github.com/aidanmorales/rTwig) package and use rgl extensively to visualize point clouds and 3d models of trees! 

Recently, I noticed that both your and my custom implementation of  `pan3d`, which you can find [here](https://github.com/aidanmorales/rTwig/blob/25f1efee0adb37873eba410c3d9f89bcb8948754/R/plot_qsm.R#L1149), have become very laggy and slow. I don't know why this changed, but I think the current reason is rgl's mouse handlers always force a redraw after every drag, even when a custom mmUSER callback (like `pan_plot()`) already redraws on its own. This creates multiple redraws instead of one. The reprex below should demonstrate the problem before and after the fix. 

```r
library(rgl)

if (!requireNamespace("rTwig", quietly = TRUE)) {
  install.packages("rTwig")
}

library(rTwig)

set.seed(1)
n <- 2000000
x <- rnorm(n)
y <- rnorm(n)
z <- rnorm(n)

rgl::open3d()
rgl::points3d(x, y, z)

rTwig:::pan_plot(button = 2)

# Right mouse button pans the figure
# Unpatched rgl: noticeable stutter
# Patched rgl: should feel smooth
```