### PR TITLE
Fix input validation in identify3d and subscenes

### DIFF
--- a/R/identify3d.R
+++ b/R/identify3d.R
@@ -31,11 +31,11 @@ identify3d <- function(x, y = NULL, z = NULL, labels = seq_along(x),
         
     buttons <- match.arg(buttons, c("left", "right", "middle"), several.ok = TRUE)
     
-    if (length(buttons > 1))
+    if (length(buttons) > 1)
       cat(gettextf("Use the %s button to select, the %s button to quit\n", 
       	           buttons[1], buttons[2]))
     else
-      cat(gettextf("Use the %s button to select\n"), buttons[1])
+      cat(gettextf("Use the %s button to select\n", buttons[1]))
 
     buttons <- c(left=1, right=2, middle=3)[buttons]
     

--- a/R/subscenes.R
+++ b/R/subscenes.R
@@ -35,7 +35,7 @@ subsceneInfo <- function(id = NA, embeddings, recursive = FALSE) {
     if (any(is.na(embeddings)) || length(embeddings) != 4)
       stop(gettextf("Four embeddings must be specified; names chosen from %s", 
       	            paste(dQuote(embeddingNames), collapse=", ")), domain = NA)
-    if (embeddings[4] == "modify")
+    if (embeddings[4] == 2L)
       stop("The mouseMode embedding cannot be 'modify'")
     .C(rgl_setEmbeddings, id = id, embeddings = as.integer(embeddings))
   }

--- a/tests/testthat/test-identify3d.R
+++ b/tests/testthat/test-identify3d.R
@@ -1,0 +1,21 @@
+library(rgl)
+
+test_that("identify3d describes a single selection button", {
+  local_mocked_bindings(
+    par3d = function(...) {
+      args <- list(...)
+      if (identical(args, list("mouseMode")))
+        return(c(left = "trackball"))
+      invisible(NULL)
+    },
+    cur3d = function() 1L,
+    rgl.setMouseCallbacks = function(...) invisible(NULL),
+    .package = "rgl"
+  )
+
+  expect_output(
+    identify3d(1, 2, 3, n = 0, buttons = "right"),
+    "Use the right button to select",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-subscene-embeddings.R
+++ b/tests/testthat/test-subscene-embeddings.R
@@ -1,0 +1,14 @@
+library(rgl)
+
+test_that("subsceneInfo rejects a modify mouseMode embedding", {
+  open3d()
+
+  expect_error(
+    subsceneInfo(
+      currentSubscene3d(),
+      embeddings = c("inherit", "inherit", "inherit", "modify")
+    ),
+    "The mouseMode embedding cannot be 'modify'",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
- `length(buttons > 1)` should be `length(buttons) > 1`; as written it is always >= 1 (truthy), so the else-branch is dead and a single-button call prints "the NA button to quit".
- In the dead else-branch, `buttons[1]` is a second argument to `cat`, not to `gettextf`, so even when fixed it would print the literal `%s`.
- After `pmatch`, `embeddings` is integer; `2L == "modify"` coerces to `"2" == "modify"`, always `FALSE`,  so the prohibition on a `"modify"` mouse embedding is never enforced.

Found with https://github.com/sims1253/ry :)